### PR TITLE
Ensure copyright notice and license are present in source files

### DIFF
--- a/config/notice.js
+++ b/config/notice.js
@@ -1,0 +1,17 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+

--- a/prosemirror-lwdita/.eslintrc
+++ b/prosemirror-lwdita/.eslintrc
@@ -3,6 +3,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": [
     "@typescript-eslint",
+    "eslint-plugin-notice",
     "eslint-plugin-tsdoc"
   ],
   "extends": [
@@ -12,6 +13,9 @@
   ],
   "rules": {
     "@typescript-eslint/no-empty-interface": 0,
-    "tsdoc/syntax": "warn"
+    "tsdoc/syntax": "warn",
+    "notice/notice":["error", {
+      "templateFile": "../config/notice.js"
+    }]
   }
 }

--- a/prosemirror-lwdita/package.json
+++ b/prosemirror-lwdita/package.json
@@ -71,6 +71,7 @@
     "chai": "^4.3.10",
     "coveralls": "^3.1.1",
     "eslint": "^8.57.0",
+    "eslint-plugin-notice": "^0.9.10",
     "eslint-plugin-tsdoc": "^0.3.0",
     "mocha": "^10.2.0",
     "nodemon": "^3.1.3",

--- a/prosemirror-lwdita/src/commands.ts
+++ b/prosemirror-lwdita/src/commands.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 export { toggleMark } from 'prosemirror-commands';
 import { canSplit } from 'prosemirror-transform';
 import { chainCommands } from 'prosemirror-commands';

--- a/prosemirror-lwdita/src/commands.ts
+++ b/prosemirror-lwdita/src/commands.ts
@@ -78,7 +78,7 @@ export function createNodesTree(tree: NodeType[]): Node {
  * This function will be called by `insertItem()` which again will be called by `menu()`.
  * `insertNode` will help to create editor buttons in the editor menu bar,
  * currently these are the buttons for creating new ordered and unordered lists.
- * menu() -> insertItem() -> insertNode()
+ * menu() -\> insertItem() -\> insertNode()
  *
  * @param type - NodeType
  * @returns Command

--- a/prosemirror-lwdita/src/document.ts
+++ b/prosemirror-lwdita/src/document.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { JDita } from "@evolvedbinary/lwdita-ast";
 import { IS_MARK, defaultNodeName } from "./schema";
 

--- a/prosemirror-lwdita/src/document.ts
+++ b/prosemirror-lwdita/src/document.ts
@@ -189,72 +189,71 @@ function travel(value: JDita, parent: JDita): any {
  * Transforms the JDita document
  * into a Schema compliant JDita document
  *
+ * @example
+ * Here's an example input:
+ * ```
+ * {
+ *   "nodeName": "document",
+ *   "children": [
+ *     {
+ *       "nodeName": "topic",
+ *       "attributes": {
+ *       "id": "intro-product"
+ *     },
+ *     {
+ *       "nodeName": "title",
+ *       "attributes": {},
+ *       "children": [
+ *         {
+ *           "nodeName": "text",
+ *           "content": "Overview"
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * @example
+ * Here's an example output of the transformation `travel(jdita, jdita)`:
+ * ```
+ * {
+ *   "type": "doc",
+ *   "attrs": {},
+ *   "content": [
+ *     {
+ *       "type": "topic",
+ *       "attrs": {
+ *         "id": "intro-product",
+ *         "parent": "doc"
+ *       },
+ *       "content": [
+ *         {
+ *           "type": "title",
+ *           "attrs": {
+ *             "parent": "topic"
+ *           },
+ *           "content": [
+ *             {
+ *               "type": "text",
+ *               "text": "Overview",
+ *               "attrs": {
+ *                 "parent": "title"
+ *               }
+ *             }
+ *           ]
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ * ```
+ *
  * @param jdita - the JDita document
  * @returns transformed JDita document
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function document(jdita: JDita): Record<string, any> {
-  /**
-   * Example input:
-  {
-    "nodeName": "document",
-    "children": [
-      {
-        "nodeName": "topic",
-        "attributes": {
-          "id": "intro-product"
-        },
-        "children": [
-          {
-            "nodeName": "title",
-            "attributes": {},
-            "children": [
-              {
-                "nodeName": "text",
-                "content": "Overview"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  */
-
-  /**
-   * Example output of the transformation `travel(jdita, jdita)`:
-  {
-    "type": "doc",
-    "attrs": {},
-    "content": [
-      {
-        "type": "topic",
-        "attrs": {
-          "id": "intro-product",
-          "parent": "doc"
-        },
-        "content": [
-          {
-            "type": "title",
-            "attrs": {
-              "parent": "topic"
-            },
-            "content": [
-              {
-                "type": "text",
-                "text": "Overview",
-                "attrs": {
-                  "parent": "title"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  */
-
   if (jdita.nodeName === 'document') {
     jdita.nodeName = 'doc';
     /*

--- a/prosemirror-lwdita/src/dom.ts
+++ b/prosemirror-lwdita/src/dom.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 /**
  * DOM nodes mapping from JDITA to HTML
  */

--- a/prosemirror-lwdita/src/index.ts
+++ b/prosemirror-lwdita/src/index.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 export * from './schema';
 export * from './document';
 export * from './plugin';

--- a/prosemirror-lwdita/src/nodes.ts
+++ b/prosemirror-lwdita/src/nodes.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 export const NODES: Record<string, string> = {
   document: 'doc',
 };

--- a/prosemirror-lwdita/src/plugin.ts
+++ b/prosemirror-lwdita/src/plugin.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { keymap } from "prosemirror-keymap";
 import { menuBar, MenuElement, MenuItem, MenuItemSpec } from "prosemirror-menu";
 import { toggleMark, newLine, hasMark, insertNode, insertImage, InputContainer } from "./commands";

--- a/prosemirror-lwdita/src/plugin.ts
+++ b/prosemirror-lwdita/src/plugin.ts
@@ -99,8 +99,10 @@ export function shortcuts(schema: Schema) {
 /**
  * Create a new instance of MenuItem and attach a command
  *
- * @example of the returned MenuItem
- * MenuItem {spec: {class: "ic-undo", enable: undo(state, dispatch), icon:{}, run: undo(state, dispatch), title: "Undo"}}
+ * @example of the returned MenuItem:
+ * ```
+ * {spec: {class: "ic-undo", enable: undo(state, dispatch), icon:{}, run: undo(state, dispatch), title: "Undo"}}
+ * ```
  *
  * @param command - The command associated with the menu item
  * @param props - The properties of the menu item
@@ -152,15 +154,19 @@ interface SimpleItemCallbacks {
  * @remarks
  * This instance of MenuItem is used for the "Debug Info" icon button in the menu
  *
- * @example of the MenuItem object
- * MenuItem {spec: {label: 'Show debug info', class: 'ic-bug', css: 'color: #c81200', enable: undefined, run}}
+ * @example of the MenuItem object:
+ * ```
+ * {spec: {label: 'Show debug info', class: 'ic-bug', css: 'color: #c81200', enable: undefined, run}}
+ * ```
  *
- * @example of the callback functions
+ * @example of the callback functions:
+ * ```
  * active:() => document.body.classList.contains('debug')
  * call:() => document.body.classList.toggle('debug')
+ * ```
  *
  * @param callbacks - callbacks `active`, `call`, e.g.
- * @param props - MenuItem properties, e.g. {label: 'Show debug info', class: 'ic-bug', css: 'color: #c81200'}
+ * @param props - MenuItem properties
  * @returns The MenuItem object
  */
 function simpleCommand(callbacks: SimpleItemCallbacks | (() => void), props: Partial<MenuItemSpec> = {}): MenuElement {

--- a/prosemirror-lwdita/src/schema.ts
+++ b/prosemirror-lwdita/src/schema.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { AbstractBaseNode, ChildTypes, DocumentNode, UnknownNodeError, getNodeClassType, nodeGroups } from '@evolvedbinary/lwdita-ast';
 import { getDomNode } from './dom';
 import { NodeSpec, Schema, SchemaSpec, Node, MarkSpec, DOMOutputSpec, Attrs } from 'prosemirror-model';

--- a/prosemirror-lwdita/src/tests/commands.spec.ts
+++ b/prosemirror-lwdita/src/tests/commands.spec.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 /**
  * Unit tests for command.ts
  */

--- a/prosemirror-lwdita/src/tests/document.spec.ts
+++ b/prosemirror-lwdita/src/tests/document.spec.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import ChaiPromised from 'chai-as-promised';
 import { use, expect, assert } from 'chai';
 import { document, NODES, _test_private_document } from '../document';

--- a/prosemirror-lwdita/src/tests/dom.spec.ts
+++ b/prosemirror-lwdita/src/tests/dom.spec.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { assert } from 'chai';
 import { getDomNode } from '../dom';
 

--- a/prosemirror-lwdita/src/tests/schema.spec.ts
+++ b/prosemirror-lwdita/src/tests/schema.spec.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { assert, expect } from 'chai';
 import { defaultNodeAttrs, defaultNodeName, defaultToDom, getDomAttr, schema, _test_private_schema, SchemaNode } from '../schema';
 import { DOMOutputSpec, MarkSpec, NodeSpec, Schema } from 'prosemirror-model';

--- a/prosemirror-lwdita/src/tests/test-utils.ts
+++ b/prosemirror-lwdita/src/tests/test-utils.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 /**
  * test-utils.ts
  *

--- a/prosemirror-lwdita/src/tests/topic.spec.ts
+++ b/prosemirror-lwdita/src/tests/topic.spec.ts
@@ -1,3 +1,20 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import ChaiPromised from 'chai-as-promised';
 import { use } from 'chai';
 import { expect } from 'chai';

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,7 @@ __metadata:
     chai-as-promised: "npm:^7.1.2"
     coveralls: "npm:^3.1.1"
     eslint: "npm:^8.57.0"
+    eslint-plugin-notice: "npm:^0.9.10"
     eslint-plugin-tsdoc: "npm:^0.3.0"
     mocha: "npm:^10.2.0"
     nodemon: "npm:^3.1.3"
@@ -2850,6 +2851,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-notice@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "eslint-plugin-notice@npm:0.9.10"
+  dependencies:
+    find-root: "npm:^1.1.0"
+    lodash: "npm:^4.17.15"
+    metric-lcs: "npm:^0.1.2"
+  peerDependencies:
+    eslint: ">=3.0.0"
+  checksum: 10c0/05b45467299d050242045e75073429c6ab6e4826bc53aba9aa15f5736782d102a6ac15aa4f36c9f564d10c04dd3f7cf4e46cff4f2a555f1b4cb828f3d533852a
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-tsdoc@npm:^0.3.0":
   version: 0.3.0
   resolution: "eslint-plugin-tsdoc@npm:0.3.0"
@@ -3084,6 +3098,13 @@ __metadata:
     make-dir: "npm:^3.0.2"
     pkg-dir: "npm:^4.1.0"
   checksum: 10c0/92747cda42bff47a0266b06014610981cfbb71f55d60f2c8216bc3108c83d9745507fb0b14ecf6ab71112bed29cd6fb1a137ee7436179ea36e11287e3159e587
+  languageName: node
+  linkType: hard
+
+"find-root@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "find-root@npm:1.1.0"
+  checksum: 10c0/1abc7f3bf2f8d78ff26d9e00ce9d0f7b32e5ff6d1da2857bcdf4746134c422282b091c672cde0572cac3840713487e0a7a636af9aa1b74cb11894b447a521efa
   languageName: node
   linkType: hard
 
@@ -4198,6 +4219,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.17.15":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
 "log-driver@npm:^1.2.7":
   version: 1.2.7
   resolution: "log-driver@npm:1.2.7"
@@ -4328,6 +4356,13 @@ __metadata:
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
+  languageName: node
+  linkType: hard
+
+"metric-lcs@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "metric-lcs@npm:0.1.2"
+  checksum: 10c0/cf5e8987cb92b3f70ca9f277268f5b525ae02195906de3b5c612d6c58341b8686241dce07cde7867d1442481f3b06f150d1d2c9f5f2a5a8c91c021ae94675edb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This uses an eslint plugin to enforce that each .ts source file has the correct Copyright notice and license header.