### PR TITLE
Handle marks in the `untravel` function

### DIFF
--- a/packages/prosemirror-lwdita/src/document.ts
+++ b/packages/prosemirror-lwdita/src/document.ts
@@ -296,8 +296,8 @@ export function unTravel(prosemirrorDocument: Record<string, any>): JDita {
   // get the node name
   const nodeName = getJditaNodeName(prosemirrorDocument.type);
 
-  if (nodeName === 'video' || nodeName === 'audio' || nodeName === 'image' || nodeName === 'text') {
-    return mediaNodeUntravel(nodeName, attributes, children, prosemirrorDocument)
+  if (nodeName === 'video' || nodeName === 'audio' || nodeName === 'image') {
+    return mediaNodeUntravel(nodeName, attributes, children)
   }
 
   // handle the attributes
@@ -305,6 +305,28 @@ export function unTravel(prosemirrorDocument: Record<string, any>): JDita {
   for (const key in attributes) {
     if (!attributes[key]) {
       delete attributes[key];
+    }
+  }
+
+  if (nodeName === 'text') {
+    // check for marks and wrap the content in the mark node
+
+    if (prosemirrorDocument.marks) {
+      const mark = prosemirrorDocument.marks[0].type;
+      return {
+        nodeName: mark,
+        attributes: attributes,
+        children: [
+          {
+            nodeName: "text",
+            content: prosemirrorDocument.text
+          }
+        ]
+      }
+    }
+    return {
+      nodeName,
+      'content': prosemirrorDocument.text
     }
   }
 
@@ -328,7 +350,7 @@ export function unTravel(prosemirrorDocument: Record<string, any>): JDita {
  * @returns JDita node
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mediaNodeUntravel(nodeName: string, attributes: Record<string, string>, children: JDita[], prosemirrorDocument: Record<string, any>): JDita {
+function mediaNodeUntravel(nodeName: string, attributes: Record<string, string>, children: JDita[]): JDita {
   if (nodeName === 'video') {
     // we must populate the video node with the necessary attributes and children
     const allAttributes = { props: attributes.props, dir: attributes.dir, "xml:lang": attributes['xml:lang'], translate: attributes.translate, id: attributes.id, conref: attributes.conref, outputclass: attributes.outputclass, class: attributes.class, width: attributes.width, height: attributes.height }
@@ -442,14 +464,6 @@ function mediaNodeUntravel(nodeName: string, attributes: Record<string, string>,
       'children': allImageChildren
     }
   }
-
-  if (nodeName === 'text') {
-    return {
-      nodeName,
-      'content': prosemirrorDocument.text
-    }
-  }
-
   throw new Error('Invalid node name');
 }
 

--- a/packages/prosemirror-lwdita/src/tests/document.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/document.spec.ts
@@ -28,7 +28,8 @@ import {
   audioXdita,
   videoXdita,
   complexXdita,
-  shortXdita
+  shortXdita,
+  bXdita
 } from './test-utils';
 import { xditaToJdita } from '@evolvedbinary/lwdita-xdita'
 import { JDita } from '@evolvedbinary/lwdita-ast';
@@ -157,6 +158,23 @@ describe('Function unTravel()', () => {
 
       // process the JDita document and do the round trip
       // clean the attributes from the top node to compare
+      originalJdita.attributes = {};
+      // transform the JDita document
+      const transformedJdita = document(originalJdita);
+      // untransform the transformed JDita document
+      const result = unTravel(transformedJdita);
+
+      //compare the original JDita with the result
+      expect(result).to.deep.equal(originalJdita);
+    });
+
+    it('handles a JDita document containing an b mark', async () => {
+
+      // original JDita to compare against
+      const originalJdita = await xditaToJdita(bXdita);
+
+      // process the JDita document and do the round trip
+      //clean the attributes from the top node to compare
       originalJdita.attributes = {};
       // transform the JDita document
       const transformedJdita = document(originalJdita);

--- a/packages/prosemirror-lwdita/src/tests/test-utils.ts
+++ b/packages/prosemirror-lwdita/src/tests/test-utils.ts
@@ -217,6 +217,17 @@ export const audioXdita = `<?xml version="1.0" encoding="UTF-8"?>
   </body>
 </topic>`;
 
+export const bXdita = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
+<topic id="program">
+  <title>Test File 2</title>
+  <body>
+    <section>
+      <p>A test <b id="one">paragraph</b>.</p>
+    </section>
+  </body>
+</topic>`;
+
 export const imageXdita = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
 <topic id="program-bulbs-to-groups">


### PR DESCRIPTION
The round trip was not able to handle text marks from a ProseMirror Document, this PR aims to address that.