### PR TITLE
Enable inserting line breaks by pressing enter

### DIFF
--- a/packages/prosemirror-lwdita-demo/cypress/e2e/newline.cy.ts
+++ b/packages/prosemirror-lwdita-demo/cypress/e2e/newline.cy.ts
@@ -1,0 +1,32 @@
+describe('inserts a line break', () => {
+    beforeEach(() => {
+        window.localStorage.setItem('file', `<?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
+    <topic id="program">
+      <title>Test File 2</title>
+      <body>
+        <section>
+          <p>A test paragraph.</p>
+        </section>
+      </body>
+    </topic>`);
+      })
+  
+  it('can insert a line break in the title', () => {
+    cy.visit('http://localhost:1234/')
+    .get('#editor > div > div.ProseMirror > article > h1')
+    .click()
+    cy.focused()
+    .type('{leftArrow}{enter}title')
+    .should('contain.html', '<br>')
+  })
+
+  it('can insert a line break in the body', () => {
+    cy.visit('http://localhost:1234/')
+    .get('#editor > div > div.ProseMirror > article > div > section > p')
+    .click()
+    cy.focused()
+    .type('{leftArrow}{enter}body')
+    .should('contain.html', '<br>')
+  })
+})

--- a/packages/prosemirror-lwdita/src/commands.ts
+++ b/packages/prosemirror-lwdita/src/commands.ts
@@ -596,13 +596,22 @@ export function enterPressed(state: EditorState, dispatch?: (tr: Transaction) =>
     $from = tr.selection.$from;
   }
 
-    // prepare the transaction
-    const resultTr: false | Transaction = isEOL(state.tr, depth)       // when the cursor is at the end of the line
-                                          ? $from.parentOffset === 0            // when the cursor is at the beginning of parent node
-                                            ? enterEmpty(tr, !!dispatch, depth) // then enterEmpty is triggered
-                                            : enterEOL(tr, !!dispatch, depth)   // when the cursor is not at the beginning of parent node, the cursor can be at the end text node, then enterEOL is triggered
-                                          : enterSplit(tr, !!dispatch, depth);  // when the cursor is not at the end of the line, then enterSplit is triggered
-
+  // prepare the transaction
+    let resultTr: false | Transaction
+ 
+  if(isEOL(state.tr, depth)) {
+    if($from.parentOffset === 0 ) {
+      resultTr = enterEmpty(tr, !!dispatch, depth)
+    } else {
+      resultTr = enterEOL(tr, !!dispatch, depth)
+    }
+  } else {
+    if($from.parentOffset === 0 ) {
+      resultTr = enterSplit(tr, !!dispatch, depth)
+    } else {
+      resultTr = tr.replaceSelectionWith(state.schema.nodes.hard_break.create()).scrollIntoView();
+    }
+  }
   // if the transaction is triggered, then dispatch the transaction
   if (dispatch && resultTr !== false) {
     dispatch(resultTr);

--- a/packages/prosemirror-lwdita/src/document.ts
+++ b/packages/prosemirror-lwdita/src/document.ts
@@ -308,6 +308,13 @@ export function unTravel(prosemirrorDocument: Record<string, any>): JDita {
     }
   }
 
+  if(nodeName === 'hard-break') {
+    return {
+      nodeName: 'text',
+      content: '\n'
+    }
+  }
+
   if (nodeName === 'text') {
     // check for marks and wrap the content in the mark node
 

--- a/packages/prosemirror-lwdita/src/schema.ts
+++ b/packages/prosemirror-lwdita/src/schema.ts
@@ -312,6 +312,13 @@ export function schema(): Schema {
         group: 'common_inline all_inline',
         inline: true,
       },
+      hard_break: {
+        inline: true,
+        group: 'common_inline all_inline',
+        selectable: false,
+        parseDOM: [{tag: "br"}],
+        toDOM() { return ["br"] }
+      } as NodeSpec
     },
     // the mark types that exist in this schema
     marks: {},

--- a/packages/prosemirror-lwdita/src/tests/schema.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/schema.spec.ts
@@ -129,7 +129,8 @@ describe('Function schema()', () => {
     // nodeNames are strings in the content array
     const nodeNames = nodes.content.filter((node: NodeSpec) => typeof node === 'string')
     const expectedNodes = [
-      'text',         'image',       'data',
+      'text',         'hard_break',
+      'image',       'data',
       'xref',         'ph',          'title',
       'shortdesc',    'prolog',      'p',
       'ol',           'dt',          'pre',
@@ -139,7 +140,7 @@ describe('Function schema()', () => {
       'strow',        'simpletable', 'fig',
       'dd',           'dlentry',     'dl',
       'li',           'ul',          'section',
-      'body',         'topic',       'doc'
+      'body',         'topic',       'doc',
     ];
     expect(nodeNames).to.have.members(expectedNodes);
   });


### PR DESCRIPTION
This PR enables inserting line breaks in the middle of text when pressing enter.
