### PR TITLE
Remove Cypress test artefacts from revision and clear Cypress downloads folder before each test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ package-lock.json
 .pnp.*
 
 # Cypress test artifacts
-prosemirror-lwdita-demo/cypress/downloads/*
+packages/prosemirror-lwdita-demo/cypress/downloads
 
 #Dockerfile
 Dockerfile

--- a/packages/prosemirror-lwdita-demo/cypress.config.ts
+++ b/packages/prosemirror-lwdita-demo/cypress.config.ts
@@ -5,5 +5,7 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
+
   },
+  trashAssetsBeforeRuns: true
 });


### PR DESCRIPTION
- This PR fixes Cypress artefacts appearing in the revision after running `yarn test:demo`, which includes downloading a file to the filesystem. 
- In addition, it configures Cypress to clear its downloads folder before initiating a test run.