### PR TITLE
Provide a functionality to handle requests

### DIFF
--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -307,3 +307,93 @@ body {
     justify-content: space-between;
   }
 }
+
+/* TODO: Customize styling for toastify */
+
+/*!
+ * Toastify js 1.12.0
+ * https://github.com/apvarun/toastify-js
+ * @license MIT licensed
+ *
+ * Copyright (C) 2018 Varun A P
+ */
+
+.toastify {
+  padding: 12px 20px;
+  color: #ffffff;
+  display: inline-block;
+  box-shadow: 0 3px 6px -1px rgba(0, 0, 0, 0.12), 0 10px 36px -4px rgba(77, 96, 232, 0.3);
+  background: -webkit-linear-gradient(315deg, #73a5ff, #5477f5);
+  background: linear-gradient(135deg, #73a5ff, #5477f5);
+  position: fixed;
+  opacity: 0;
+  transition: all 0.4s cubic-bezier(0.215, 0.61, 0.355, 1);
+  border-radius: 2px;
+  cursor: pointer;
+  text-decoration: none;
+  max-width: calc(50% - 20px);
+  z-index: 2147483647;
+}
+
+.toastify.on {
+  opacity: 1;
+}
+
+.toast-close {
+  background: transparent;
+  border: 0;
+  color: white;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 1em;
+  opacity: 0.4;
+  padding: 0 5px;
+}
+
+.toastify-right {
+  right: 15px;
+}
+
+.toastify-left {
+  left: 15px;
+}
+
+.toastify-top {
+  top: -150px;
+}
+
+.toastify-bottom {
+  bottom: -150px;
+}
+
+.toastify-rounded {
+  border-radius: 25px;
+}
+
+.toastify-avatar {
+  width: 1.5em;
+  height: 1.5em;
+  margin: -7px 5px;
+  border-radius: 2px;
+}
+
+.toastify-center {
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
+  max-width: fit-content;
+  max-width: -moz-fit-content;
+}
+
+@media only screen and (max-width: 360px) {
+
+  .toastify-right,
+  .toastify-left {
+    margin-left: auto;
+    margin-right: auto;
+    left: 0;
+    right: 0;
+    max-width: fit-content;
+  }
+}

--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -323,8 +323,14 @@ body {
   color: #ffffff;
   display: inline-block;
   box-shadow: 0 3px 6px -1px rgba(0, 0, 0, 0.12), 0 10px 36px -4px rgba(77, 96, 232, 0.3);
-  background: -webkit-linear-gradient(315deg, #73a5ff, #5477f5);
-  background: linear-gradient(135deg, #73a5ff, #5477f5);
+  // Original toastify default:
+  //background: -webkit-linear-gradient(315deg, #73a5ff, #5477f5);
+  //background: linear-gradient(135deg, #73a5ff, #5477f5);
+  //Custom Types, "saved for later"
+  //background: linear-gradient(to right, #00b09b, #96c93d);
+  //background: linear-gradient(to right, #17a2b8, #63f2f1);
+  //background: linear-gradient(to right, #ffc107, #ff9800);
+  //background: linear-gradient(to right, #ff5f5f, #ffc390);
   position: fixed;
   opacity: 0;
   transition: all 0.4s cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -384,6 +390,22 @@ body {
   right: 0;
   max-width: fit-content;
   max-width: -moz-fit-content;
+}
+
+// Custom types of toasts
+.toast {
+  &--success {
+    background-color: #4caf50;
+  }
+  &--error {
+    background-color: #f44336;
+  }
+  &--warning {
+    background-color: #ff9800;
+  }
+  &--info {
+    background-color: #00bcd4;
+  }
 }
 
 @media only screen and (max-width: 360px) {

--- a/packages/prosemirror-lwdita/package.json
+++ b/packages/prosemirror-lwdita/package.json
@@ -56,6 +56,7 @@
     "@evolvedbinary/lwdita-xdita": "^3.0.0",
     "@types/chai-as-promised": "^7.1.3",
     "chai-as-promised": "^7.1.2",
+    "notyf": "^3.10.0",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-history": "^1.4.1",
     "prosemirror-keymap": "^1.2.2",

--- a/packages/prosemirror-lwdita/package.json
+++ b/packages/prosemirror-lwdita/package.json
@@ -56,7 +56,6 @@
     "@evolvedbinary/lwdita-xdita": "^3.0.0",
     "@types/chai-as-promised": "^7.1.3",
     "chai-as-promised": "^7.1.2",
-    "notyf": "^3.10.0",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-history": "^1.4.1",
     "prosemirror-keymap": "^1.2.2",

--- a/packages/prosemirror-lwdita/package.json
+++ b/packages/prosemirror-lwdita/package.json
@@ -65,12 +65,14 @@
     "prosemirror-schema-list": "^1.4.0",
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.8.0",
-    "prosemirror-view": "^1.32.7"
+    "prosemirror-view": "^1.32.7",
+    "toastify-js": "^1.12.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.10",
+    "@types/toastify-js": "^1",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "chai": "^4.3.10",

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -33,20 +33,25 @@ const validParameters = ['ghrepo', 'source', 'referer'];
  * @param url - URL string
  * @returns String with parsing result
  */
-export function hasValidParameters(url: string): string {
+export function parseParameters(url: string): string {
   const parsedUrl = new URL(url);
-  if (parsedUrl.search !== '') {
-    for (const parameter of validParameters) {
-      // Some of the expected parameters are missing
-      if (!parsedUrl.searchParams.has(parameter)) {
-        return 'invalidParams';
-      }
+  let allParametersPresent = true;
+  for (const parameter of validParameters) {
+    if (!parsedUrl.searchParams.has(parameter)) {
+      allParametersPresent = false;
+      break;
     }
-    // Every expected parameter has been found
-    return 'validParams';
   }
-  // Will be the case when requsting the the Petal website link
-  return 'noParams';
+  if (allParametersPresent) {
+    // All required params are present
+    return 'validParams';
+  } else if (parsedUrl.search === '') {
+    // No params are present
+    return 'noParams';
+  } else {
+    // One or more params are missing
+    return 'invalidParams';
+  }
 }
 
 /**
@@ -58,13 +63,15 @@ export function hasValidParameters(url: string): string {
  * @returns Array with the URL parameter values
  */
 export function getParameterValues(url: string): { key: string, value: string }[] {
-  if (hasValidParameters(url) === 'validParams') {
+  if (parseParameters(url) === 'validParams') {
     const parsedUrl = new URL(url);
     const parameters = validParameters.map((key) => ({
       key,
       value: parsedUrl.searchParams.get(key)!,
     }));
+    console.log('validParams')
     if (parameters.some(({ value }) => value === null)) {
+      console.log('Missing values for parameters')
       throw new Error('Missing values for parameters');
     }
     return parameters;

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -15,10 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Notyf } from 'notyf';
-import 'notyf/notyf.min.css';
-
-const notyf = new Notyf();
+import { showToast } from './toast';
 
 /**
  * List of valid URL parameters
@@ -90,16 +87,16 @@ export function processRequest(): void {
       const parameters = getParameterValues(currentUrl);
       // TODO: Process the parameters for redirecting to GitHub OAuth
       console.log('parameters', parameters);
-      notyf.success('Success! You will be redirected to GitHub OAuth');
+      showToast('Success! You will be redirected to GitHub OAuth', 'success');
     } catch (error) {
 
       if (error instanceof Error) {
         if (error.message === 'Missing values for parameters') {
-          notyf.error('Your request is invalid. Please check if you have missing values for parameters');
+          showToast('Your request is invalid. Please check if you have missing values for parameters', 'warning');
         } else if (error.message === 'Invalid parameters') {
           // Redirect to Petal website
           // window.location.href = 'http://localhost:1234/';
-          notyf.error('Your request is invalid. You are being redirected to http://localhost:1234/');
+          showToast('Your request is invalid. You are being redirected to http://localhost:1234/', 'error');
         }
       } else {
         console.error(error);

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -15,10 +15,14 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-export * from './schema';
-export * from './document';
-export * from './plugin';
-export * from './commands';
-export * from './untravel-document';
-export * from './attributes';
-export * from './request';
+/**
+ * Checks if the URL has any parameters or not and returns a boolean
+ * @param url - URL string
+ * @returns Boolean
+ */
+export const hasParameters = (url: string): boolean => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [path, queryString] = url.split('?');
+  return !!queryString;
+};
+

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -15,6 +15,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
+
 /**
  * List of valid URL parameters
  * ghrepo = GitHub repository,

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -16,13 +16,57 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /**
- * Checks if the URL has any parameters or not and returns a boolean
- * @param url - URL string
- * @returns Boolean
+ * List of valid URL parameters
+ * ghrepo = GitHub repository,
+ * source = GitHub resource,
+ * referer = Referer of the request
  */
-export const hasParameters = (url: string): boolean => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [path, queryString] = url.split('?');
-  return !!queryString;
-};
+const validParameters = ['ghrepo', 'source', 'referer'];
 
+/**
+ * Parses the URL and checks if the URL has all the expected parameters
+ * `ghrepo`, `source`, and `referer`
+ * Will return a string with the parsing result
+ *
+ * @param url - URL string
+ * @returns String with parsing result
+ */
+export function hasValidParameters(url: string): string {
+  const parsedUrl = new URL(url);
+  if (parsedUrl.search !== '') {
+    for (const parameter of validParameters) {
+      // Some of the expected parameters are missing
+      if (!parsedUrl.searchParams.has(parameter)) {
+        return 'invalidParams';
+      }
+    }
+    // Every expected parameter has been found
+    return 'validParams';
+  }
+  // Will be the case when requsting the the Petal website link
+  return 'noParams';
+}
+
+/**
+ * Retrieves the values of the valid URL parameters
+ * `ghrepo`, `source`, and `referer`.
+ * Will throw an error if the URL has missing values or invalid parameters
+ *
+ * @param url - URL string
+ * @returns Array with the URL parameter values
+ */
+export function getParameterValues(url: string): { key: string, value: string }[] {
+  if (hasValidParameters(url) === 'validParams') {
+    const parsedUrl = new URL(url);
+    const parameters = validParameters.map((key) => ({
+      key,
+      value: parsedUrl.searchParams.get(key)!,
+    }));
+    if (parameters.some(({ value }) => value === null)) {
+      throw new Error('Missing values for parameters');
+    }
+    return parameters;
+  } else {
+    throw new Error('Invalid parameters');
+  }
+}

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -116,4 +116,4 @@ export function processRequest(): void {
  /**
   * Start the process of processing the URL parameters
   */
-export const inititalRequest = processRequest();
+export const initialRequest = processRequest();

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -75,3 +75,39 @@ export function getParameterValues(url: string): { key: string, value: string }[
     throw new Error('Invalid parameters');
   }
 }
+
+/**
+ * Process the URL and redirect to GitHub OAuth
+ * or show notifications if the URL is invalid
+ */
+export function processRequest(): void {
+  // Check if the window object is defined (i.e. it is not in Mocha tests!)
+  if (typeof window !== 'undefined') {
+    const currentUrl = window.location.href;
+    //console.log('currentUrl', currentUrl);
+
+    try {
+      const parameters = getParameterValues(currentUrl);
+      // TODO: Process the parameters for redirecting to GitHub OAuth
+      console.log('parameters', parameters);
+      notyf.success('Success! You will be redirected to GitHub OAuth');
+    } catch (error) {
+
+      if (error instanceof Error) {
+        if (error.message === 'Missing values for parameters') {
+          notyf.error('Your request is invalid. Please check if you have missing values for parameters');
+        } else if (error.message === 'Invalid parameters') {
+          // Redirect to Petal website
+          // window.location.href = 'http://localhost:1234/';
+          notyf.error('Your request is invalid. You are being redirected to http://localhost:1234/');
+        }
+      } else {
+        console.error(error);
+      }
+    }
+  } else {
+    console.log('Window is not defined');
+  }
+}
+
+processRequest();

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -24,7 +24,7 @@ use(ChaiPromised);
 let urlWithoutParameters: string, urlWithParameters : string;
 
 // check if the URL has parameters
-describe.only('Function hasParameters()', () => {
+describe('Function hasParameters()', () => {
   urlWithoutParameters = 'https://example.com/';
   urlWithParameters = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
 

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -1,0 +1,39 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { hasParameters } from '../request';
+import ChaiPromised from 'chai-as-promised';
+import { use, expect } from 'chai';
+
+use(ChaiPromised);
+
+let urlWithoutParameters: string, urlWithParameters : string;
+
+// check if the URL has parameters
+describe.only('Function hasParameters()', () => {
+  urlWithoutParameters = 'https://example.com/';
+  urlWithParameters = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
+
+  it('returns false if the URL has no parameters', () => {
+    expect(hasParameters(urlWithoutParameters)).to.equal(false);
+  });
+
+  it('returns true if the URL has parameters', () => {
+    expect(hasParameters(urlWithParameters)).to.equal(true);
+  });
+})
+

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { hasValidParameters, getParameterValues } from '../request';
+import { parseParameters, getParameterValues } from '../request';
 import ChaiPromised from 'chai-as-promised';
 import { use, expect } from 'chai';
 
@@ -27,20 +27,20 @@ let validUrl: string, invalidUrl: string;
 
 
 // check all the URL parameter values
-describe('Function hasValidParameters()', () => {
+describe('Function parseParameters()', () => {
   it('returns String "validParams" if the URL has all the expected parameters', () => {
     validUrl = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
-    expect(hasValidParameters(validUrl)).to.equal('validParams');
+    expect(parseParameters(validUrl)).to.equal('validParams');
   });
 
   it('returns string "invalidParams" if the URL has not all the expected parameters', () => {
     invalidUrl = 'https://example.com/?ghrepo=repo1&source=source1';
-    expect(hasValidParameters(invalidUrl)).to.equal('invalidParams');
+    expect(parseParameters(invalidUrl)).to.equal('invalidParams');
   });
 
   it('returns string "noParams" if the URL has no parameters at all', () => {
     invalidUrl = 'https://example.com/';
-    expect(hasValidParameters(invalidUrl)).to.equal('noParams');
+    expect(parseParameters(invalidUrl)).to.equal('noParams');
   });
 })
 
@@ -72,4 +72,6 @@ it('returns the URL parameter values', () => {
 })
 
 // Process the request
+
+
 // TODO: check if the request was successful

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -70,3 +70,6 @@ it('returns the URL parameter values', () => {
     expect(() => getParameterValues(invalidUrl)).to.throw();
   });
 })
+
+// Process the request
+// TODO: check if the request was successful

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -15,63 +15,63 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { parseParameters, getParameterValues } from '../request';
+import { getParameterValues, isValidParam } from '../request';
 import ChaiPromised from 'chai-as-promised';
 import { use, expect } from 'chai';
 
 use(ChaiPromised);
 
 let validUrl: string, invalidUrl: string;
+const url: string = 'https://example.com/';
 
-// Parse the URL and check for expected parameters
-
-
-// check all the URL parameter values
-describe('Function parseParameters()', () => {
-  it('returns String "validParams" if the URL has all the expected parameters', () => {
-    validUrl = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
-    expect(parseParameters(validUrl)).to.equal('validParams');
+// Function getParameterValues()
+describe('When function getParameterValues() is passed a URL with', () => {
+  it('valid parameters, it returns an object containing key-value pairs', () => {
+    validUrl = url + '?ghrepo=repo1&source=source1&referer=referer1';
+      expect(getParameterValues(validUrl)).to.deep.equal([
+      { key: 'ghrepo', value: 'repo1' },
+      { key: 'source', value: 'source1' },
+      { key: 'referer', value: 'referer1' },
+    ]);
   });
 
-  it('returns string "invalidParams" if the URL has not all the expected parameters', () => {
-    invalidUrl = 'https://example.com/?ghrepo=repo1&source=source1';
-    expect(parseParameters(invalidUrl)).to.equal('invalidParams');
+  it('a missing value of any of the keys, it returns string "invalidParams"', () => {
+    invalidUrl = url + '?ghrepo=ghrepo1&source=source1&referer=';
+    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
-  it('returns string "noParams" if the URL has no parameters at all', () => {
-    invalidUrl = 'https://example.com/';
-    expect(parseParameters(invalidUrl)).to.equal('noParams');
-  });
-})
-
-// Get the values of the valid URL parameters
-describe('Function getParameterValues()', () => {
-  it('returns the correct amount of valid URL parameter values', () => {
-    validUrl = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
-    expect(getParameterValues(validUrl)).to.have.lengthOf(3);
+  it('one missing parameter, it returns string "invalidParams"', () => {
+    invalidUrl = url + '?ghrepo=ghrepo1&source=source1&referer';
+    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
-it('returns the URL parameter values', () => {
-  validUrl = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
-  expect(getParameterValues(validUrl)).to.deep.equal([
-    { key: 'ghrepo', value: 'repo1' },
-    { key: 'source', value: 'source1' },
-    { key: 'referer', value: 'referer1' },
-  ]);
-});
-
-  it('throws an error if the URL has missing parameter values', () => {
-    invalidUrl = 'https://example.com/?ghrepo=&source=source1';
-    expect(() => getParameterValues(invalidUrl)).to.throw();
+  it('two missing parameters, it returns string "invalidParams"', () => {
+    invalidUrl = url + '?ghrepo';
+    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
-  it('throws an error if the URL has invalid parameters', () => {
-    invalidUrl = 'https://example.com/?ghrepo=repo1&source=source1';
-    expect(() => getParameterValues(invalidUrl)).to.throw();
+  it('any parameter that is not matching any of the expected keys, it returns string "invalidParams"', () => {
+    invalidUrl = url + '?xyz';
+    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
+  });
+
+  it('no parameters at all, it returns string "noParams"', () => {
+    invalidUrl = url;
+    expect(getParameterValues(invalidUrl)).to.equal('noParams');
   });
 })
 
-// Process the request
+// Function isValidParam()
+describe('When function isValidParam() is passed a key', () => {
+  it('that is a valid key, it returns true', () => {
+    expect(isValidParam('ghrepo')).to.equal(true);
+    expect(isValidParam('source')).to.equal(true);
+    expect(isValidParam('referer')).to.equal(true);
+  });
+  it('that is a invalid key, it returns true', () => {
+    expect(isValidParam('xyz')).to.equal(false);
+  });
+})
 
-
-// TODO: check if the request was successful
+// Function showNotification()
+// TODO: This needs to be tested in Cypress as it requires browser testing.

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -15,25 +15,58 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { hasParameters } from '../request';
+import { hasValidParameters, getParameterValues } from '../request';
 import ChaiPromised from 'chai-as-promised';
 import { use, expect } from 'chai';
 
 use(ChaiPromised);
 
-let urlWithoutParameters: string, urlWithParameters : string;
+let validUrl: string, invalidUrl: string;
 
-// check if the URL has parameters
-describe('Function hasParameters()', () => {
-  urlWithoutParameters = 'https://example.com/';
-  urlWithParameters = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
+// Parse the URL and check for expected parameters
 
-  it('returns false if the URL has no parameters', () => {
-    expect(hasParameters(urlWithoutParameters)).to.equal(false);
+
+// check all the URL parameter values
+describe('Function hasValidParameters()', () => {
+  it('returns String "validParams" if the URL has all the expected parameters', () => {
+    validUrl = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
+    expect(hasValidParameters(validUrl)).to.equal('validParams');
   });
 
-  it('returns true if the URL has parameters', () => {
-    expect(hasParameters(urlWithParameters)).to.equal(true);
+  it('returns string "invalidParams" if the URL has not all the expected parameters', () => {
+    invalidUrl = 'https://example.com/?ghrepo=repo1&source=source1';
+    expect(hasValidParameters(invalidUrl)).to.equal('invalidParams');
+  });
+
+  it('returns string "noParams" if the URL has no parameters at all', () => {
+    invalidUrl = 'https://example.com/';
+    expect(hasValidParameters(invalidUrl)).to.equal('noParams');
   });
 })
 
+// Get the values of the valid URL parameters
+describe('Function getParameterValues()', () => {
+  it('returns the correct amount of valid URL parameter values', () => {
+    validUrl = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
+    expect(getParameterValues(validUrl)).to.have.lengthOf(3);
+  });
+
+it('returns the URL parameter values', () => {
+  validUrl = 'https://example.com/?ghrepo=repo1&source=source1&referer=referer1';
+  expect(getParameterValues(validUrl)).to.deep.equal([
+    { key: 'ghrepo', value: 'repo1' },
+    { key: 'source', value: 'source1' },
+    { key: 'referer', value: 'referer1' },
+  ]);
+});
+
+  it('throws an error if the URL has missing parameter values', () => {
+    invalidUrl = 'https://example.com/?ghrepo=&source=source1';
+    expect(() => getParameterValues(invalidUrl)).to.throw();
+  });
+
+  it('throws an error if the URL has invalid parameters', () => {
+    invalidUrl = 'https://example.com/?ghrepo=repo1&source=source1';
+    expect(() => getParameterValues(invalidUrl)).to.throw();
+  });
+})

--- a/packages/prosemirror-lwdita/src/toast.ts
+++ b/packages/prosemirror-lwdita/src/toast.ts
@@ -15,9 +15,16 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import Toastify from 'toastify-js';
 
-// Function to display a toast message with 'Toastify' library
+/**
+ * Displays a toast message with 'Toastify' library
+ *
+ * @param message - Message to display
+ * @param type - Type of toast
+ */
 export function showToast(message: string, type: 'success' | 'error' | 'warning' | 'info') {
   const toast = Toastify({
     text: message,

--- a/packages/prosemirror-lwdita/src/toast.ts
+++ b/packages/prosemirror-lwdita/src/toast.ts
@@ -15,11 +15,17 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-export * from './schema';
-export * from './document';
-export * from './plugin';
-export * from './commands';
-export * from './untravel-document';
-export * from './attributes';
-export * from './request';
-export * from './toast';
+import Toastify from 'toastify-js';
+
+// Function to display a toast message with 'Toastify' library
+export function showToast(message: string, type: 'success' | 'error' | 'warning' | 'info') {
+  const toast = Toastify({
+    text: message,
+    duration: 10000,
+    gravity: 'bottom',
+    position: 'right',
+    style: {
+      background: type === 'success' ? 'linear-gradient(to right, #00b09b, #96c93d)' : 'linear-gradient(to right, #ff5f5f, #ffc390)',
+    },
+  }).showToast();
+}

--- a/packages/prosemirror-lwdita/src/toast.ts
+++ b/packages/prosemirror-lwdita/src/toast.ts
@@ -31,8 +31,6 @@ export function showToast(message: string, type: 'success' | 'error' | 'warning'
     duration: 10000,
     gravity: 'bottom',
     position: 'right',
-    style: {
-      background: type === 'success' ? 'linear-gradient(to right, #00b09b, #96c93d)' : 'linear-gradient(to right, #ff5f5f, #ffc390)',
-    },
+    className: `toast toast--${type}`,
   }).showToast();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,7 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.3.0"
     mocha: "npm:^10.6.0"
     nodemon: "npm:^3.1.4"
+    notyf: "npm:^3.10.0"
     nyc: "npm:^17.0.0"
     prosemirror-commands: "npm:^1.5.2"
     prosemirror-history: "npm:^1.4.1"
@@ -5930,6 +5931,13 @@ __metadata:
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
+  languageName: node
+  linkType: hard
+
+"notyf@npm:^3.10.0":
+  version: 3.10.0
+  resolution: "notyf@npm:3.10.0"
+  checksum: 10c0/949e767f84f409f6b6e00026a82268afebf29385bcbd711491ca9a11a30e8545cf186253740ece9b89ce066bcb4ac79ab7b5170a7d56c0013f1ed7501788c313
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,6 +406,7 @@ __metadata:
     "@types/chai-as-promised": "npm:^7.1.3"
     "@types/mocha": "npm:^10.0.7"
     "@types/node": "npm:^20.14.10"
+    "@types/toastify-js": "npm:^1"
     "@typescript-eslint/eslint-plugin": "npm:^7.16.0"
     "@typescript-eslint/parser": "npm:^7.16.0"
     chai: "npm:^4.3.10"
@@ -428,6 +429,7 @@ __metadata:
     prosemirror-transform: "npm:^1.8.0"
     prosemirror-view: "npm:^1.32.7"
     rimraf: "npm:^6.0.1"
+    toastify-js: "npm:^1.12.0"
     ts-node: "npm:^10.9.2"
     typedoc: "npm:^0.26.5"
     typedoc-plugin-missing-exports: "npm:^3.0.0"
@@ -1968,6 +1970,13 @@ __metadata:
   version: 2.3.8
   resolution: "@types/sizzle@npm:2.3.8"
   checksum: 10c0/ab5460147ae6680cc20c2223a8f17d9f7c97144b70f00a222a1c32d68b5207696d48177ab9784dda88c74d93ed5a78dd31f74d271b15382520b423c81b4aac89
+  languageName: node
+  linkType: hard
+
+"@types/toastify-js@npm:^1":
+  version: 1.12.3
+  resolution: "@types/toastify-js@npm:1.12.3"
+  checksum: 10c0/e886fdef7c110eed0a2eece0fd1c2292f696d722409e8cc66f583ebf33a36feface876524710b202b167a17c8937451b60add302e4600e103ef93c6ba740b311
   languageName: node
   linkType: hard
 
@@ -7470,6 +7479,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"toastify-js@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "toastify-js@npm:1.12.0"
+  checksum: 10c0/493584aa0980f89f52da55643a20b2436f9a459a639358ec39519a590fad59ef8356ab5404010c330f47ccb2ca0ce2c237cee8235580d7e52ed60c179125e2e3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,7 +417,6 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.3.0"
     mocha: "npm:^10.6.0"
     nodemon: "npm:^3.1.4"
-    notyf: "npm:^3.10.0"
     nyc: "npm:^17.0.0"
     prosemirror-commands: "npm:^1.5.2"
     prosemirror-history: "npm:^1.4.1"
@@ -5940,13 +5939,6 @@ __metadata:
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
-  languageName: node
-  linkType: hard
-
-"notyf@npm:^3.10.0":
-  version: 3.10.0
-  resolution: "notyf@npm:3.10.0"
-  checksum: 10c0/949e767f84f409f6b6e00026a82268afebf29385bcbd711491ca9a11a30e8545cf186253740ece9b89ce066bcb4ac79ab7b5170a7d56c0013f1ed7501788c313
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR provides a functionality that allows to handle requests to the Petal website. 
The request URL will be parsed and validated. 
If the validation succeeds, a parameter object containing key and values will be stored and the user will be shown a "success" notification.
If the parameters don't comply with the expected keys, the user will be shown an "error" notification.
If no parameters were received, an "info" notification will be shown for development purposes (should be deleted later, or get an updated content).

### How to test this PR

#### 1. Test the demo in the browser

```
rm -rf node_modules/
yarn install
yarn clean && yarn build & yarn start:demo
```
Insert several URLs in the Petal demo page and check the logs and the notifications. You can have a look at the unit tests for tested example parameters to test in the browser.

#### 2. Run tests

```
yarn test
```