### PR TITLE
User Data end point and functions

### DIFF
--- a/packages/prosemirror-lwdita-backend/package.json
+++ b/packages/prosemirror-lwdita-backend/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@octokit/auth-oauth-user": "^5.1.1",
     "@octokit/rest": "^21.0.2",
+    "@octokit/types": "^13.5.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "octokit": "^4.0.2"

--- a/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
+++ b/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
@@ -21,12 +21,20 @@ export const authenticateUserWithOctokit = async (req: Request, res: Response) =
   res.json(token);
 };
 
+/**
+ * Retrieves authenticated user information using the provided token.
+ * @param req - The request object.
+ * @param res - The response object.
+ * @returns A JSON response containing the user information.
+ */
 export const getUserInformation = async (req: Request, res: Response) => {
-  const token = req.query.token;
-  if (!token) {
-    return res.status(400).json({ message: "Missing token" });
+  if (!req.headers.authorization) {
+    return res.status(403).json({ error: 'No credentials sent!' });
   }
-  // dynamically import the module
+  // the token is sent as a Bearer token in the Authorization header
+  const token = req.headers.authorization.split(' ')[1];
+  
+  // dynamically import the module to avoid EMS and CJS incompatibility
   const { getUserInfo } = await import('../modules/octokit.module.mjs');
 
   const userInfo = await getUserInfo(token as string);

--- a/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
+++ b/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
@@ -20,3 +20,15 @@ export const authenticateUserWithOctokit = async (req: Request, res: Response) =
 
   res.json(token);
 };
+
+export const getUserInformation = async (req: Request, res: Response) => {
+  const token = req.query.token;
+  if (!token) {
+    return res.status(400).json({ message: "Missing token" });
+  }
+  // dynamically import the module
+  const { getUserInfo } = await import('../modules/octokit.module.mjs');
+
+  const userInfo = await getUserInfo(token as string);
+  res.json(userInfo);
+};

--- a/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
+++ b/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
@@ -1,9 +1,10 @@
 import { Octokit } from "@octokit/rest";
 import { App } from 'octokit';
+import { Endpoints } from "@octokit/types";
 import dotenv from 'dotenv'; 
 dotenv.config();  // Load environment variables from .env file 
 
-
+export type UserData = Endpoints["GET /user"]["response"]["data"];
 /**
  * Authenticates with OAuth using the provided code.
  * @param code - The OAuth code to authenticate with.
@@ -38,3 +39,21 @@ export const authenticateWithOAuth = async (code: string): Promise<string | unde
     console.error("Error during OAuth authentication", error);
   }
 }
+
+/**
+ * Gets information about the authenticated user.
+ * @param token - The authentication token.
+ * @returns A promise that resolves to the user information.
+ */
+export const getUserInfo = async (token: string): Promise<UserData | undefined> => {
+  try {
+    const octokit = new Octokit({
+      auth: token
+    });
+
+    const { data } = await octokit.users.getAuthenticated();
+    return data;
+  } catch (error) {
+    console.error("Error getting user information", error);
+  }
+};

--- a/packages/prosemirror-lwdita-backend/src/api/routes/github.router.ts
+++ b/packages/prosemirror-lwdita-backend/src/api/routes/github.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { authenticateUserWithOctokit } from '../controller/github.controller';
+import { authenticateUserWithOctokit, getUserInformation } from '../controller/github.controller';
 
 const router = Router();
 
@@ -11,5 +11,8 @@ router.get('/', (req, res) => {
 
 // GET /api/github/token exchange user code for token
 router.get('/token', authenticateUserWithOctokit);
+
+// GET /api/github/user get user information
+router.get('/user', getUserInformation);
 
 export default router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,6 +361,7 @@ __metadata:
   dependencies:
     "@octokit/auth-oauth-user": "npm:^5.1.1"
     "@octokit/rest": "npm:^21.0.2"
+    "@octokit/types": "npm:^13.5.0"
     "@types/dotenv": "npm:^8.2.0"
     "@types/express": "npm:^4.17.21"
     dotenv: "npm:^16.4.5"


### PR DESCRIPTION
This PR add the functionality to get the user data and creates the endpoint `/api/github/user`.

This Should be look at after #370  is done.
# How to test this PR
* checkout the branch `octokit/user-data`
* install any new dependencies using `yarn install`
* start the server using `yarn start:backend`
* copy the token you got before from the auth process, or generate a new one by making a request to `https://github.com/login/oauth/authorize?client_id=` add the client id.
* Make a `GET` request to `http://localhost:3000/api/github/user` and the token as a bearer Token in the authorization header.
```sh
curl --location 'localhost:3000/api/github/user' \
--header 'Authorization:bearer ••••••'
```
* the response must contain your GitHub information.