### PR TITLE
Fetch Github Raw document And transform to prosemirror document

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -10,11 +10,15 @@ import { doubleClickImagePlugin } from '@evolvedbinary/prosemirror-lwdita'
 
 const schemaObject = schema();
 
+// if the user passes a file in the URL, load that file
+// otherwise load the default file
+const loadJsonDoc = jsonDocLoader;
+
 /**
  * Load the json document and create a new EditorView.
  * The json document is transformed from JDITA to ProseMirror Schema
  */
-jsonDocLoader.then(jsonDoc => {
+loadJsonDoc.then(jsonDoc => {
   // get the editor element from the DOM
   const domEl = document.querySelector("#editor") as HTMLElement;
   // clear the element innerHTML

--- a/packages/prosemirror-lwdita/package.json
+++ b/packages/prosemirror-lwdita/package.json
@@ -56,6 +56,7 @@
     "@evolvedbinary/lwdita-xdita": "^3.0.0",
     "@types/chai-as-promised": "^7.1.3",
     "chai-as-promised": "^7.1.2",
+    "fetch-mock": "^11.1.3",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-history": "^1.4.1",
     "prosemirror-keymap": "^1.2.2",

--- a/packages/prosemirror-lwdita/src/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github.plugin.ts
@@ -1,0 +1,57 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { xditaToJdita } from "@evolvedbinary/lwdita-xdita";
+import { document as jditaToProsemirrorJson } from "./document";
+
+/**
+ * Fetches the raw content of a document from a GitHub repository.
+ *
+ * @param ghrepo - The GitHub repository in the format "owner/repo".
+ * @param source - The path to the file within the repository.
+ * @returns A promise that resolves to the raw content of the document as a string.
+ *
+ * @remarks
+ * This function currently fetches the document from the 'main' branch of the repository.
+ * should use the GitHub API to dynamically determine the default branch of the repository.
+ */
+export const fetchRawDocumentFromGitHub = async (ghrepo: string, source: string): Promise<string> => {
+  // https://raw.githubusercontent.com/evolvedbinary/prosemirror-lwdita/main/packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml
+  // We have an issue of the branch, we should use the default branch of the repo
+  //TODO(YB): We should use the GitHub API to get the default branch of the repo
+  const url = `https://raw.githubusercontent.com/${ghrepo}/main/${source}`;
+  const response = await fetch(url);
+
+  //TODO: Handle errors
+  return response.text();
+};
+
+/**
+ * Transforms a raw GitHub document into a ProseMirror state save.
+ *
+ * @param rawDocument - The raw xdita document as a string.
+ * @returns A promise that resolves to a record containing the ProseMirror state save.
+ */
+export const transformGitHubDocumentToProsemirrorJson = async (rawDocument: string): Promise<Record<string, any>> => {
+  // convert the raw xdita document to jdita
+  const jdita = await xditaToJdita(rawDocument);
+
+  // convert the jdita document to prosemirror state save
+  const prosemirrorJson = await jditaToProsemirrorJson(jdita);
+
+  return prosemirrorJson;
+};

--- a/packages/prosemirror-lwdita/src/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github.plugin.ts
@@ -46,6 +46,7 @@ export const fetchRawDocumentFromGitHub = async (ghrepo: string, source: string)
  * @param rawDocument - The raw xdita document as a string.
  * @returns A promise that resolves to a record containing the ProseMirror state save.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const transformGitHubDocumentToProsemirrorJson = async (rawDocument: string): Promise<Record<string, any>> => {
   // convert the raw xdita document to jdita
   const jdita = await xditaToJdita(rawDocument);

--- a/packages/prosemirror-lwdita/src/index.ts
+++ b/packages/prosemirror-lwdita/src/index.ts
@@ -23,3 +23,4 @@ export * from './untravel-document';
 export * from './attributes';
 export * from './request';
 export * from './toast';
+export * from './github.plugin';

--- a/packages/prosemirror-lwdita/src/tests/github.plugin.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/github.plugin.spec.ts
@@ -1,0 +1,66 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { expect } from 'chai';
+import { fetchRawDocumentFromGitHub, transformGitHubDocumentToProsemirrorJson } from '../github.plugin';
+import fetchMock from 'fetch-mock';
+import { shortXdita, shortXditaProsemirroJson } from './test-utils';
+
+describe('fetchRawDocumentFromGitHub', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('should fetch the raw content of a document from a GitHub repository', async () => {
+    const ghrepo = 'evolvedbinary/prosemirror-lwdita';
+    const source = 'packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml';
+    const mockResponse = '<xml>Mock Content</xml>';
+    // this will mock the next fetch request
+    fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/main/${source}`, {
+      body: mockResponse,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+    const result = await fetchRawDocumentFromGitHub(ghrepo, source);
+    expect(result).to.equal(mockResponse);
+  });
+
+  it('should handle errors when fetching the document', async () => {
+    const ghrepo = 'evolvedbinary/prosemirror-lwdita';
+    const source = 'packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml';
+    // this will mock the next fetch request
+    fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/main/${source}`, 404);
+
+    try {
+      await fetchRawDocumentFromGitHub(ghrepo, source);
+      throw new Error('Expected fetchRawDocumentFromGitHub to throw an error');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+  });
+});
+
+describe('transformGitHubDocumentToProsemirrorJson', () => {
+  it('should transform a raw GitHub document into a ProseMirror state save', async () => {
+    const mockXdita = shortXdita;
+    
+    const prosemirrorJson = await transformGitHubDocumentToProsemirrorJson(mockXdita)
+
+    const mockJson = shortXditaProsemirroJson;
+    expect(prosemirrorJson).to.deep.equal(mockJson)
+  });
+});

--- a/packages/prosemirror-lwdita/src/tests/test-utils.ts
+++ b/packages/prosemirror-lwdita/src/tests/test-utils.ts
@@ -118,6 +118,68 @@ export const shortXdita = `<?xml version="1.0" encoding="UTF-8"?>
   </body>
 </topic>`;
 
+export const shortXditaProsemirroJson = {
+  type: "doc",
+  attrs: {
+  },
+  content: [
+    {
+      type: "topic",
+      attrs: {
+        id: "program",
+        parent: "doc",
+      },
+      content: [
+        {
+          type: "title",
+          attrs: {
+            parent: "topic",
+          },
+          content: [
+            {
+              type: "text",
+              text: "Test File 2",
+              attrs: {
+                parent: "title",
+              },
+            },
+          ],
+        },
+        {
+          type: "body",
+          attrs: {
+            parent: "topic",
+          },
+          content: [
+            {
+              type: "section",
+              attrs: {
+                parent: "body",
+              },
+              content: [
+                {
+                  type: "p",
+                  attrs: {
+                    parent: "section",
+                  },
+                  content: [
+                    {
+                      type: "text",
+                      text: "A test paragraph.",
+                      attrs: {
+                        parent: "p",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 export const complexXdita = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
 <topic id="fullTopic">

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,6 +420,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     eslint-plugin-notice: "npm:^1.0.0"
     eslint-plugin-tsdoc: "npm:^0.3.0"
+    fetch-mock: "npm:^11.1.3"
     mocha: "npm:^10.6.0"
     nodemon: "npm:^3.1.4"
     nyc: "npm:^17.0.0"
@@ -2192,6 +2193,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/glob-to-regexp@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "@types/glob-to-regexp@npm:0.4.4"
+  checksum: 10c0/7288ff853850d8302a8770a3698b187fc3970ad12ee6427f0b3758a3e7a0ebb0bd993abc6ebaaa979d09695b4194157d2bfaa7601b0fb9ed72c688b4c1298b88
+  languageName: node
+  linkType: hard
+
 "@types/http-errors@npm:*":
   version: 2.0.4
   resolution: "@types/http-errors@npm:2.0.4"
@@ -3538,6 +3546,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
 "destroy@npm:1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
@@ -4183,6 +4198,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-mock@npm:^11.1.3":
+  version: 11.1.3
+  resolution: "fetch-mock@npm:11.1.3"
+  dependencies:
+    "@types/glob-to-regexp": "npm:^0.4.4"
+    dequal: "npm:^2.0.3"
+    glob-to-regexp: "npm:^0.4.1"
+    is-subset: "npm:^0.1.1"
+    regexparam: "npm:^3.0.0"
+  peerDependenciesMeta:
+    node-fetch:
+      optional: true
+  checksum: 10c0/087b4d25f4852fc6fa6aadf0b6735958e5f1f75321f8dc12054f2704cfe9f2d0878a62e639de6ecb5b18305c178a5985a321b67478aaafd41d17d207344db45e
+  languageName: node
+  linkType: hard
+
 "figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -4537,6 +4568,13 @@ __metadata:
   dependencies:
     is-glob: "npm:^4.0.3"
   checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
+  languageName: node
+  linkType: hard
+
+"glob-to-regexp@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "glob-to-regexp@npm:0.4.1"
+  checksum: 10c0/0486925072d7a916f052842772b61c3e86247f0a80cc0deb9b5a3e8a1a9faad5b04fb6f58986a09f34d3e96cd2a22a24b7e9882fb1cf904c31e9a310de96c429
   languageName: node
   linkType: hard
 
@@ -5093,6 +5131,13 @@ __metadata:
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
+  languageName: node
+  linkType: hard
+
+"is-subset@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "is-subset@npm:0.1.1"
+  checksum: 10c0/d8125598ab9077a76684e18726fb915f5cea7a7358ed0c6ff723f4484d71a0a9981ee5aae06c44de99cfdef0fefce37438c6257ab129e53c82045ea0c2acdebf
   languageName: node
   linkType: hard
 
@@ -7054,6 +7099,13 @@ __metadata:
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 10c0/12b069dc774001fbb0014f6a28f11c09ebfe3c0d984d88c9bced77fdb6fedbacbca434d24da9ae9371bfbf23f754869307fb51a4c98a8b8b18e5ef748677ca24
+  languageName: node
+  linkType: hard
+
+"regexparam@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "regexparam@npm:3.0.0"
+  checksum: 10c0/a6430d7b97d5a7d5518f37a850b6b73aab479029d02f46af4fa0e8e4a1d7aad05b7a0d2d10c86ded21a14d5f0fa4c68525f873a5fca2efeefcccd93c36627459
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds two new functions that will be used for the GitHub integration:
*  `fetchRawDocumentFromGitHub`  Fetch the Raw document from Github.
*  `transformGitHubDocumentToProsemirrorJson` Transform the `xdita` to `Jdita` then to `prosemirrorJson`.

 # How to test the PR:
 * checkout the branch
 * install new dependencies `yarn install`
 * run the tests `yarn run test`