### PR TITLE
Optional UI element for publishing based on URLParams

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -103,6 +103,50 @@ export function openFileMenuItem(): MenuElement {
 }
 
 /**
+ * Creates a menu item for publishing to Github.
+ * This function generates a menu item that allows users to publish a file
+ *
+ * @returns {MenuElement} The menu item for publishing the file.
+ */
+export function publishFileMenuItem(): MenuElement {
+  //const storedFile = localStorage.getItem('file') ? localStorage.getItem('file') : console.log('No file in the localStorage to save.');
+  const storedFileName = localStorage.getItem('fileName') ? localStorage.getItem('fileName') : 'Petal';
+
+  return new MenuItem({
+    enable: () => true,
+    render(editorView) {
+      const el = document.createElement('div');
+      el.classList.add('ProseMirror-menuitem-file');
+      const link = document.createElement('a');
+      link.download = storedFileName + '.xml';
+      link.textContent = 'Publish "' + storedFileName + '.xml"';
+      link.id = 'publishFile';
+      el.appendChild(link);
+      return el;
+    },
+    class: 'ic-github',
+    run: publishGithubDocument()
+  });
+}
+
+/**
+ * Creates a command that publishes the current document to GitHub.
+ *
+ * @returns {Command} A ProseMirror command function.
+ */
+function publishGithubDocument(): Command {
+  return (state: {[x: string]: any; tr: any; selection: { empty: any; };}, dispatch: (arg0: any) => void) => {
+    if (dispatch) {
+      dispatch(state.tr);
+      console.log('Publishing the document to GitHub...');
+      // show the publishing dialog
+    } else {
+      console.log('Nothing to publish, no EditorState has been dispatched.');
+    }
+  }
+}
+
+/**
  * Create a menu item to save a file to the filesystem
  * @returns A MenuElement
  */

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -6,13 +6,12 @@ import jsonDocLoader from "./doc";
 import { menu, shortcuts } from "@evolvedbinary/prosemirror-lwdita";
 import { githubMenuItem, openFileMenuItem, publishFileMenuItem, saveFileMenuItem} from "./demo-plugin";
 import { history } from "prosemirror-history";
-import { doubleClickImagePlugin } from '@evolvedbinary/prosemirror-lwdita'
+import { doubleClickImagePlugin, processRequest } from '@evolvedbinary/prosemirror-lwdita'
 
 const schemaObject = schema();
 
 // flag whether the url params are set or not
-//TODO(YB): this should be set based on the URL params
-const urlParams = false;
+const urlParams = processRequest();
 
 /**
  * Load the json document and create a new EditorView.

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -11,7 +11,7 @@ import { doubleClickImagePlugin } from '@evolvedbinary/prosemirror-lwdita'
 const schemaObject = schema();
 
 // flag whether the url params are set or not
-const urlParams = true;
+const urlParams = false;
 
 /**
  * Load the json document and create a new EditorView.
@@ -40,7 +40,7 @@ jsonDocLoader.then(jsonDoc => {
             githubMenuItem({ label: 'prosemirror-lwdita', url: 'https://github.com/evolvedbinary/prosemirror-lwdita' }),
           ]],
           start: [[
-            urlParams? openFileMenuItem() : publishFileMenuItem(),
+            urlParams? publishFileMenuItem() : openFileMenuItem(),
             saveFileMenuItem()
           ]],
         }),

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -10,7 +10,9 @@ import { doubleClickImagePlugin, processRequest } from '@evolvedbinary/prosemirr
 
 const schemaObject = schema();
 
-// flag whether the url params are set or not
+/**
+ * Process the URL parameters and handle the notifications
+ */
 const urlParams = processRequest();
 
 /**

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -4,11 +4,14 @@ import { Node } from "prosemirror-model";
 import { schema } from "@evolvedbinary/prosemirror-lwdita";
 import jsonDocLoader from "./doc";
 import { menu, shortcuts } from "@evolvedbinary/prosemirror-lwdita";
-import { githubMenuItem, openFileMenuItem, saveFileMenuItem} from "./demo-plugin";
+import { githubMenuItem, openFileMenuItem, publishFileMenuItem, saveFileMenuItem} from "./demo-plugin";
 import { history } from "prosemirror-history";
 import { doubleClickImagePlugin } from '@evolvedbinary/prosemirror-lwdita'
 
 const schemaObject = schema();
+
+// flag whether the url params are set or not
+const urlParams = true;
 
 /**
  * Load the json document and create a new EditorView.
@@ -37,7 +40,7 @@ jsonDocLoader.then(jsonDoc => {
             githubMenuItem({ label: 'prosemirror-lwdita', url: 'https://github.com/evolvedbinary/prosemirror-lwdita' }),
           ]],
           start: [[
-            openFileMenuItem(),
+            urlParams? openFileMenuItem() : publishFileMenuItem(),
             saveFileMenuItem()
           ]],
         }),

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -11,6 +11,7 @@ import { doubleClickImagePlugin } from '@evolvedbinary/prosemirror-lwdita'
 const schemaObject = schema();
 
 // flag whether the url params are set or not
+//TODO(YB): this should be set based on the URL params
 const urlParams = false;
 
 /**

--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -77,6 +77,17 @@ body {
                 text-decoration: none;
               }
             }
+            .ic-github {
+              margin-left: 1rem;
+              display:flex;
+              align-items: center;
+              gap: .4rem;
+
+              a {
+                color: inherit;
+                text-decoration: none;
+              }
+            }
             & > * {
               cursor: pointer;
               line-height: $height;

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -92,7 +92,7 @@ export function showNotification(parameters: 'validParams' | 'invalidParams' | '
 /**
  * Process the URL parameters and handle the notifications
  */
-export function processRequest(): void {
+export function processRequest(): undefined | string | { key: string, value: string }[] {
   // Check if the window object is defined (i.e. it is not in Mocha tests!)
   if (typeof window !== 'undefined') {
     const currentUrl = window.location.href;
@@ -101,6 +101,7 @@ export function processRequest(): void {
       const parameters = getParameterValues(currentUrl);
       showNotification(parameters);
       console.log('Parameters =', JSON.stringify(parameters));
+      return parameters;
     } catch (error) {
       if (error instanceof Error) {
         showToast('An unknown error has occurred. Please check the console.', 'error');
@@ -112,8 +113,3 @@ export function processRequest(): void {
     }
   }
 }
-
- /**
-  * Start the process of processing the URL parameters
-  */
-export const initialRequest = processRequest();

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -92,7 +92,7 @@ export function showNotification(parameters: 'validParams' | 'invalidParams' | '
 /**
  * Process the URL parameters and handle the notifications
  */
-export function processRequest(): undefined | string | { key: string, value: string }[] {
+export function processRequest(): undefined | { key: string, value: string }[] {
   // Check if the window object is defined (i.e. it is not in Mocha tests!)
   if (typeof window !== 'undefined') {
     const currentUrl = window.location.href;
@@ -101,7 +101,10 @@ export function processRequest(): undefined | string | { key: string, value: str
       const parameters = getParameterValues(currentUrl);
       showNotification(parameters);
       console.log('Parameters =', JSON.stringify(parameters));
-      return parameters;
+      if(typeof parameters === 'object') {
+        return parameters;
+      }
+      
     } catch (error) {
       if (error instanceof Error) {
         showToast('An unknown error has occurred. Please check the console.', 'error');


### PR DESCRIPTION
Display UI elements “Open File” and “Publish” Button depending on called endpoints.
![image](https://github.com/user-attachments/assets/75a54c2a-9d17-4bcb-b251-65fbe9a28ad7)

# How to test
* checkout the branch
* start the demo server `yarn run start:demo`
* set `urlParams` to `false` in `example.ts`
* check the UI changes.
* click the publish button
* check the console for the output from the function `publishGithubDocument`