### PR TITLE
[bugfix] Fix evaluating inclomplete parameter key-value pairs

### DIFF
--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -50,7 +50,7 @@ export function getParameterValues(url: string): 'validParams' | 'invalidParams'
   }
 
   const hasMissingValues = parameters.some(({ value }) => value === null || value === '');
-  const hasInvalidParams = parameters.some(({ key }) => !isValidParam(key));
+  const hasInvalidParams = validKeys.some(key => !params.has(key));
 
   // Return the status string for the notifications
   if (hasMissingValues || hasInvalidParams) {

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -45,6 +45,11 @@ describe('When function getParameterValues() is passed a URL with', () => {
     expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
+  it('one valid parameter, but the rest is missing, it returns string "invalidParams"', () => {
+    invalidUrl = url + '?ghrepo=xyz';
+    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
+  });
+
   it('two missing parameters, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo';
     expect(getParameterValues(invalidUrl)).to.equal('invalidParams');


### PR DESCRIPTION
Before, the check for parameters was returning true if only one valid valid key-value pair was found. Now it checks for all of the three key-value pairs to be complete and only then turns "validParams" (true).