### PR TITLE
Redirect users to GitHub to authenticate Github Petal App

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -139,6 +139,7 @@ function publishGithubDocument(): Command {
     if (dispatch) {
       dispatch(state.tr);
       console.log('Publishing the document to GitHub...');
+      //window.location.href = 'https://github.com/login/oauth/authorize?client_id=Iv23li0Pvl3E4crXIBQ0'
       // show the publishing dialog
     } else {
       console.log('Nothing to publish, no EditorState has been dispatched.');
@@ -221,7 +222,7 @@ function transformToJditaDocumentNode(state: { [x: string]: any; tr?: any; selec
   const serializer = new JditaSerializer(outStream, true);
 
   serializer.serializeFromJdita(documentNode);
-  
+
   return outStream.getText();
   ;
 };

--- a/packages/prosemirror-lwdita/src/config.ts
+++ b/packages/prosemirror-lwdita/src/config.ts
@@ -1,0 +1,21 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export const clientID: { id: string, value: string } = {
+  id: 'client_id',
+  value: 'Iv23li0Pvl3E4crXIBQ0',
+};

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getParameterValues, isValidParam } from '../request';
+import { getAndValidateParameterValues, isValidParam } from '../request';
 import ChaiPromised from 'chai-as-promised';
 import { use, expect } from 'chai';
 
@@ -28,7 +28,7 @@ const url: string = 'https://example.com/';
 describe('When function getParameterValues() is passed a URL with', () => {
   it('valid parameters, it returns an object containing key-value pairs', () => {
     validUrl = url + '?ghrepo=repo1&source=source1&referer=referer1';
-      expect(getParameterValues(validUrl)).to.deep.equal([
+    expect(getAndValidateParameterValues(validUrl)).to.deep.equal([
       { key: 'ghrepo', value: 'repo1' },
       { key: 'source', value: 'source1' },
       { key: 'referer', value: 'referer1' },
@@ -37,32 +37,32 @@ describe('When function getParameterValues() is passed a URL with', () => {
 
   it('a missing value of any of the keys, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo=ghrepo1&source=source1&referer=';
-    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
   it('one missing parameter, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo=ghrepo1&source=source1&referer';
-    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
   it('one valid parameter, but the rest is missing, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo=xyz';
-    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
   it('two missing parameters, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo';
-    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
   it('any parameter that is not matching any of the expected keys, it returns string "invalidParams"', () => {
     invalidUrl = url + '?xyz';
-    expect(getParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
   });
 
   it('no parameters at all, it returns string "noParams"', () => {
     invalidUrl = url;
-    expect(getParameterValues(invalidUrl)).to.equal('noParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('noParams');
   });
 })
 


### PR DESCRIPTION
#### Description

This PR redirects successful redirects to the Petal app to GitHub authentication.

#### How to test this PR

1. Install PR 
```
rm -rf node_modules/
yarn install
yarn clean && yarn build && yarn start:demo
```
2. Open a **new blank tab** and insert a test URL, i.e. `localhost:1234/?ghrepo=ghrepo1&source=source1&referer=referer1` to mock a redirect coming from an external page to Petal.

3. The result should either redirect you to the GitHub Authentication page or directly return the user code if the authentication has been granted in a previous session (note that the toast will indicate "invalid params", because handling the response is out of scope for this PR).

