### PR TITLE
Encapsulate and fix CSS styling for the publish button in the editor toolbar

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -116,7 +116,7 @@ export function publishFileMenuItem(): MenuElement {
     enable: () => true,
     render(editorView) {
       const el = document.createElement('div');
-      el.classList.add('ProseMirror-menuitem-file');
+      el.classList.add('ProseMirror-menuitem-file', 'publish');
       const link = document.createElement('a');
       link.download = storedFileName + '.xml';
       link.textContent = 'Publish "' + storedFileName + '.xml"';

--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -77,7 +77,7 @@ body {
                 text-decoration: none;
               }
             }
-            .ic-github {
+            .ic-github.publish {
               margin-left: 1rem;
               display:flex;
               align-items: center;


### PR DESCRIPTION
This PR fixes the styling for the new "Publish" button and the old GitHub link buttons in the toolbar-.

Previously the rules for the `.ic-github` class were having side-effects on the other GitHub buttons in the toolbar. 
I have added another class to the publish button in order to specify the css selector and to avoid the side-effects.

