### PR TITLE
Handle oauth response from github

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -10,14 +10,15 @@ import { doubleClickImagePlugin, processRequest } from '@evolvedbinary/prosemirr
 
 const schemaObject = schema();
 
-// if the user passes a file in the URL, load that file
-// otherwise load the default file
-const loadJsonDoc = jsonDocLoader;
-
 /**
  * Process the URL parameters and handle the notifications
  */
 const urlParams = processRequest();
+// TODO(YB): fetch and render the file from the URL
+
+// if the user passes a file in the URL, load that file
+// otherwise load the default file
+const loadJsonDoc = jsonDocLoader;
 
 /**
  * Load the json document and create a new EditorView.

--- a/packages/prosemirror-lwdita/src/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github.plugin.ts
@@ -30,9 +30,7 @@ import { document as jditaToProsemirrorJson } from "./document";
  * should use the GitHub API to dynamically determine the default branch of the repository.
  */
 export const fetchRawDocumentFromGitHub = async (ghrepo: string, source: string): Promise<string> => {
-  // https://raw.githubusercontent.com/evolvedbinary/prosemirror-lwdita/main/packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml
-  // We have an issue of the branch, we should use the default branch of the repo
-  //TODO(YB): We should use the GitHub API to get the default branch of the repo
+  //TODO(YB): the branch should be passed as a parameter
   const url = `https://raw.githubusercontent.com/${ghrepo}/main/${source}`;
   const response = await fetch(url);
 
@@ -55,4 +53,21 @@ export const transformGitHubDocumentToProsemirrorJson = async (rawDocument: stri
   const prosemirrorJson = await jditaToProsemirrorJson(jdita);
 
   return prosemirrorJson;
+};
+
+/**
+ * Exchanges an OAuth code for an access token.
+ *
+ * @param code - The OAuth code to exchange for an access token.
+ * @returns A promise that resolves to the access token as a string.
+ * @throws Will throw an error if the fetch request fails or if the response is not in the expected format.
+ */
+export const exchangeOAuthCodeForAccessToken = async (code: string): Promise<string> => {
+  // build the URL to exchange the code for an access token
+  const url = `/api/github/token?code=${code}`;
+  // fetch the access token
+  const response = await fetch(url);
+  const json = await response.json();
+  //TODO: Handle errors
+  return json.token;
 };

--- a/packages/prosemirror-lwdita/src/request.ts
+++ b/packages/prosemirror-lwdita/src/request.ts
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { showToast } from './toast';
 import { clientID } from './config';
+import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
 /**
  * List of valid URL key names in parameters
@@ -34,7 +35,7 @@ export const validKeys = ['ghrepo', 'source', 'referer'];
  * @param url - URL string
  * @returns An array with key-value objects of the URL parameter values or a status string for handling the notifications
  */
-export function getAndValidateParameterValues(url: string): 'validParams' | 'invalidParams' | 'noParams' | { key: string, value: string }[] {
+export function getAndValidateParameterValues(url: string): 'invalidParams' | 'noParams' | { key: string, value: string }[] {
   const parameters: { key: string, value: string }[] = [];
 
   const urlParts = url.split('?');
@@ -48,6 +49,13 @@ export function getAndValidateParameterValues(url: string): 'validParams' | 'inv
   // Loop through the parameters and add them to the array
   for (const [key, value] of params.entries()) {
     parameters.push({ key, value });
+  }
+
+  // check if the URL parameters are from oauth redirect
+  for (const param of parameters) {
+    if (isOAuthCodeParam(param.key)) {
+      return parameters;
+    }
   }
 
   const hasMissingValues = parameters.some(({ value }) => value === null || value === '');
@@ -75,18 +83,24 @@ export function isValidParam(key: string): boolean {
   return validKeys.includes(key);
 }
 
+export function isOAuthCodeParam(key: string): boolean {
+  return key === 'code';
+}
+
 /**
  * Shows a toast notification based on the given parameters
  *
  * @param parameters - The URL parameters
  */
-export function showNotification(parameters: 'validParams' | 'invalidParams' | 'noParams' | { key: string, value: string }[]): void {
+export function showNotification(parameters: 'authenticated' | 'invalidParams' | 'noParams' | { key: string, value: string }[]): void {
   if (typeof parameters === 'object') {
     showToast('Success! You will be redirected to GitHub OAuth', 'success');
   } else if (parameters === 'invalidParams') {
     showToast('Your request is invalid.', 'error');
   } else if (parameters === 'noParams') {
     showToast('Welcome to the Petal Demo Website.', 'info');
+  } else if(parameters === 'authenticated') {
+    showToast('You are authenticated.', 'success');
   }
 }
 
@@ -109,17 +123,49 @@ export function processRequest(): undefined | { key: string, value: string }[] {
 
     try {
       const parameters = getAndValidateParameterValues(currentUrl);
+      
       if (typeof parameters === 'string') {
+        if(parameters === 'invalidParams') {
+          //TODO(YB): Redirect to referer if it exists
+          //TODO(YB): Redirect to Petal error page if referer doesn't exist
+        }
         showNotification(parameters);
-      }
 
-      if (typeof parameters === 'object') {
+        return undefined;
+      } else if (typeof parameters === 'object' && !parameters.some(param => isOAuthCodeParam(param.key))) {
         // Store the parameters in localStorage for reading the values after the OAuth flow
         // TODO: After a successful GitHub Authentication, read the user parameters from localStorage and clear it afterwards
         localStorage.setItem('userParams', JSON.stringify(parameters));
 
         // Redirect to GitHub OAuth page
         redirectToGitHubOAuth();
+      } else if (typeof parameters === 'object' && parameters.some(param => isOAuthCodeParam(param.key))) {
+        //TODO(YB): These Params should passed with the OAuth redirect URL
+        // get the stored parameters from localStorage
+        const storedParams = localStorage.getItem('userParams');
+        if(!storedParams) {
+          // TODO: Redirect to Petal error page
+          // we should never reach here
+          return undefined;
+        }
+
+        // exchange the code for an access token
+        const codeParam = parameters.find(param => param.key === 'code');
+        if (!codeParam) return undefined; // I don't understand why this is necessary as the previous if statement should have caught this
+        const code = codeParam.value;
+        
+
+        exchangeOAuthCodeForAccessToken(code).then(token => {
+          localStorage.setItem('token', token);
+        }).catch(e => {
+          console.error(e);
+        });
+
+        // Show a success notification
+        showNotification("authenticated");
+
+        // return the stored parameters and the new parameters from the URL
+        return JSON.parse(storedParams);
       }
 
     } catch (error) {

--- a/packages/prosemirror-lwdita/src/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/src/tests/request.spec.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getAndValidateParameterValues, isValidParam } from '../request';
+import { getAndValidateParameterValues, isOAuthCodeParam, isValidParam } from '../request';
 import ChaiPromised from 'chai-as-promised';
 import { use, expect } from 'chai';
 
@@ -64,6 +64,11 @@ describe('When function getParameterValues() is passed a URL with', () => {
     invalidUrl = url;
     expect(getAndValidateParameterValues(invalidUrl)).to.equal('noParams');
   });
+
+  it('OAuth code parameter, it returns an object containing key-value pairs', () => {
+    validUrl = url + '?code=xyz';
+    expect(getAndValidateParameterValues(validUrl)).to.deep.equal([{ key: 'code', value: 'xyz' }]);
+  });
 })
 
 // Function isValidParam()
@@ -77,6 +82,16 @@ describe('When function isValidParam() is passed a key', () => {
     expect(isValidParam('xyz')).to.equal(false);
   });
 })
+
+describe('When function isOAuthCodeParam() is passed a key', () => {
+  it('that is an OAuth code key, it returns true', () => {
+    expect(isOAuthCodeParam('code')).to.equal(true);
+  });
+
+  it('that is not an OAuth code key, it returns false', () => {
+    expect(isOAuthCodeParam('xyz')).to.equal(false);
+  });
+});
 
 // Function showNotification()
 // TODO: This needs to be tested in Cypress as it requires browser testing.


### PR DESCRIPTION
Handles the OAuth redirect from GitHub, exchanges the user code for a token, show a toast to the user when he is authenticated.

# How to test this PR:
* checkout the branch
* install dependencies `yarn install`
* run tests `yarn run test`
* start the demo `yarn run start:demo`
* make a request to `http://localhost:1234/?ghrepo=grergeerger&source=hdhtdrhdrhtrdh&referer=htwsrhtshrts`
* you should be redirect to GitHub OAuth, authorize petal.
* you will be redirected back to `http://localhost:1234/?code=xyz`
* you will see a toast notification saying `authenticated`
 