### PR TITLE
Fetch and render the github document if the user opened petal from EDIT ME link

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -6,24 +6,21 @@ import jsonDocLoader from "./doc";
 import { menu, shortcuts } from "@evolvedbinary/prosemirror-lwdita";
 import { githubMenuItem, openFileMenuItem, publishFileMenuItem, saveFileMenuItem} from "./demo-plugin";
 import { history } from "prosemirror-history";
-import { doubleClickImagePlugin, processRequest, fetchAndTransform } from '@evolvedbinary/prosemirror-lwdita'
+import { doubleClickImagePlugin, processRequest, fetchAndTransform, URLParams } from '@evolvedbinary/prosemirror-lwdita'
 
 const schemaObject = schema();
 
 /**
  * Process the URL parameters and handle the notifications
  */
-const urlParams = processRequest() as { key: string, value: string }[];
+const urlParams = processRequest() as URLParams | undefined;
 
 // if the user passes a file in the URL, load that file
 // otherwise load the default file
 let loadJsonDoc = jsonDocLoader;
 if(urlParams) {
-  const ghrepo = urlParams.find((param) => param.key === 'ghrepo');
-  const source = urlParams.find((param) => param.key === 'source');
-
   // create a new promise to fetch the raw document from GitHub then transform it to ProseMirror JSON
-  loadJsonDoc = fetchAndTransform(ghrepo?.value, source?.value);
+  loadJsonDoc = fetchAndTransform(urlParams.ghrepo, urlParams.source);
 }
 
 /**

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -6,7 +6,7 @@ import jsonDocLoader from "./doc";
 import { menu, shortcuts } from "@evolvedbinary/prosemirror-lwdita";
 import { githubMenuItem, openFileMenuItem, publishFileMenuItem, saveFileMenuItem} from "./demo-plugin";
 import { history } from "prosemirror-history";
-import { doubleClickImagePlugin, processRequest, fetchRawDocumentFromGitHub, transformGitHubDocumentToProsemirrorJson } from '@evolvedbinary/prosemirror-lwdita'
+import { doubleClickImagePlugin, processRequest, fetchAndTransform } from '@evolvedbinary/prosemirror-lwdita'
 
 const schemaObject = schema();
 
@@ -23,7 +23,7 @@ if(urlParams) {
   const source = urlParams.find((param) => param.key === 'source');
 
   // create a new promise to fetch the raw document from GitHub then transform it to ProseMirror JSON
-  loadJsonDoc = fetchRawDocumentFromGitHub(ghrepo?.value, source?.value).then((rawDoc: string) => transformGitHubDocumentToProsemirrorJson(rawDoc));
+  loadJsonDoc = fetchAndTransform(ghrepo?.value, source?.value);
 }
 
 /**
@@ -66,6 +66,7 @@ loadJsonDoc.then(jsonDoc => {
     });
   }
 }).catch(e => {
+  //TODO(YB): This should be the fall back page when we can't load the file
   console.error(e);
   const h2 = document.createElement('h2');
   h2.innerText = 'Failed to load the file';

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -6,19 +6,25 @@ import jsonDocLoader from "./doc";
 import { menu, shortcuts } from "@evolvedbinary/prosemirror-lwdita";
 import { githubMenuItem, openFileMenuItem, publishFileMenuItem, saveFileMenuItem} from "./demo-plugin";
 import { history } from "prosemirror-history";
-import { doubleClickImagePlugin, processRequest } from '@evolvedbinary/prosemirror-lwdita'
+import { doubleClickImagePlugin, processRequest, fetchRawDocumentFromGitHub, transformGitHubDocumentToProsemirrorJson } from '@evolvedbinary/prosemirror-lwdita'
 
 const schemaObject = schema();
 
 /**
  * Process the URL parameters and handle the notifications
  */
-const urlParams = processRequest();
-// TODO(YB): fetch and render the file from the URL
+const urlParams = processRequest() as { key: string, value: string }[];
 
 // if the user passes a file in the URL, load that file
 // otherwise load the default file
-const loadJsonDoc = jsonDocLoader;
+let loadJsonDoc = jsonDocLoader;
+if(urlParams) {
+  const ghrepo = urlParams.find((param) => param.key === 'ghrepo');
+  const source = urlParams.find((param) => param.key === 'source');
+
+  // create a new promise to fetch the raw document from GitHub then transform it to ProseMirror JSON
+  loadJsonDoc = fetchRawDocumentFromGitHub(ghrepo?.value, source?.value).then((rawDoc: string) => transformGitHubDocumentToProsemirrorJson(rawDoc));
+}
 
 /**
  * Load the json document and create a new EditorView.

--- a/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
@@ -46,13 +46,26 @@ export const fetchRawDocumentFromGitHub = async (ghrepo: string, source: string)
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const transformGitHubDocumentToProsemirrorJson = async (rawDocument: string): Promise<Record<string, any>> => {
-  // convert the raw xdita document to jdita
-  const jdita = await xditaToJdita(rawDocument);
+    // convert the raw xdita document to jdita
+    const jdita = await xditaToJdita(rawDocument);
+    
+    // convert the jdita document to prosemirror state save
+    const prosemirrorJson = await jditaToProsemirrorJson(jdita);
+    
+    return prosemirrorJson;
+};
 
-  // convert the jdita document to prosemirror state save
-  const prosemirrorJson = await jditaToProsemirrorJson(jdita);
-
-  return prosemirrorJson;
+/**
+ * Fetches a raw document from a GitHub repository and transforms it into a ProseMirror JSON document.
+ *
+ * @param ghrepo - The GitHub repository from which to fetch the document.
+ * @param source - The source path of the document within the repository.
+ * @returns A promise that resolves to the transformed ProseMirror JSON document.
+ */
+export const fetchAndTransform = async (ghrepo: string, source: string) => {
+  const rawDoc = await fetchRawDocumentFromGitHub(ghrepo, source);
+  const jsonDoc = await transformGitHubDocumentToProsemirrorJson(rawDoc);
+  return jsonDoc;
 };
 
 /**

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -20,6 +20,13 @@ import { clientID } from '../config';
 import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
 /**
+ * Interface for the URL parameters
+ */
+export interface URLParams {
+  [key: string]: string;
+}
+
+/**
  * List of valid URL key names in parameters
  * ghrepo = GitHub repository,
  * source = GitHub resource,
@@ -113,7 +120,7 @@ export function redirectToGitHubOAuth(): void {
 /**
  * Process the URL parameters and handle the notifications
  */
-export function processRequest(): undefined | { key: string, value: string }[] {
+export function processRequest(): undefined | URLParams {
   // Check if the window object is defined (i.e. it is not in Mocha tests!)
   if (typeof window !== 'undefined') {
     const currentUrl = window.location.href;
@@ -168,8 +175,18 @@ export function processRequest(): undefined | { key: string, value: string }[] {
         // Show a success notification
         showNotification("authenticated");
 
+        const returnParams: URLParams = {};
+
+        // Add the stored parameters to the returnParams object
+        if (storedParams) {
+          const stored = JSON.parse(storedParams);
+          for (const param of stored) {
+            returnParams[param.key] = param.value;
+          }
+        }
+
         // return the stored parameters and the new parameters from the URL
-        return JSON.parse(storedParams);
+        return returnParams;
       }
 
     } catch (error) {


### PR DESCRIPTION
Fetch the raw document from GitHub then transform it into a prosemirror state json.

# How to test this PR
* Checkout the branch `git checkout feature/render`
* Install dependencies `yarn install`
* Start the demo `yarn run start:demo`
* Make a request to `http://localhost:1234/?ghrepo=evolvedbinary/prosemirror-lwdita&source=packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml&referer=htwsrhtshrts`
* Authenticate Petal Github APP 
* `02-short-file.xml` should be rendered on the editor
![image](https://github.com/user-attachments/assets/575da1e9-1d5d-41a6-9cab-7a27daff0939)