### PR TITLE
Handle user redirect after error / invalid request

### DIFF
--- a/packages/prosemirror-lwdita-demo/auth-error.html
+++ b/packages/prosemirror-lwdita-demo/auth-error.html
@@ -1,0 +1,53 @@
+<!--
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<!doctype html>
+<html lang=en>
+
+<head>
+  <meta charset=utf-8>
+  <title>Petal - In-Browser LwDITA Editor - Error Page</title>
+  <link rel="stylesheet" href="style/style.scss">
+  <link rel="stylesheet" href="style/icons.css">
+</head>
+
+<body>
+  <div class="main error">
+    <div class="editor-container">
+      <header class="header">
+        <h1>Petal - In-browser LwDITA Editor - Error</h1>
+        <a href="https://www.evolvedbinary.com"><img class="eb-logo"
+            src="https://evolvedbinary.com/images/icons/ev-logo.svg" /></a>
+      </header>
+
+      <main class="pt-main">
+        <section class="pt-section">
+          <div class="pt-container">
+            <h2>Authentication Failed</h2>
+            <p>
+              We're sorry to inform you that your GitHub authentication failed, and we couldn't find the page you were trying to
+              edit.
+            </p>
+            <p>
+              No worries, you can simply close this page and reach out to the maintainers of the page if you need any assistance.
+            </p>
+          </div>
+        </section>
+      </main>
+  </div>
+</body>
+</html>

--- a/packages/prosemirror-lwdita-demo/package.json
+++ b/packages/prosemirror-lwdita-demo/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf dist",
     "build": "parcel build ./index.html",
     "prepack": "yarn run build",
-    "start": "parcel ./index.html",
+    "start": "parcel ./index.html ./auth-error.html",
     "docker": "yarn build && node docker",
     "cypress": "cypress open",
     "test": "start-server-and-test start http://localhost:1234 cy:run",

--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -14,18 +14,34 @@ body {
   display: flex;
 }
 
+.pt-container {
+  width: 100%;
+  @media screen and (min-width: 400px) {
+    width: 60vw;
+    margin: 4rem auto;
+  }
+
+  > h2 {
+    margin-top: 0;
+  }
+}
+
 .main {
   display: flex;
   flex: 1;
   background-color: whitesmoke;
+  &.error {
+    background-color: #fff;
+  }
   .editor-container {
     display: flex;
     flex-direction: column;
     flex: 1;
     // background-color: #2b579a;
-    background-color: #f16999;
+
     .header {
       color: white;
+      background-color: #f16999;
       padding: 12px 24px;
       h1 {
         display: inline;

--- a/packages/prosemirror-lwdita/src/config.ts
+++ b/packages/prosemirror-lwdita/src/config.ts
@@ -19,3 +19,8 @@ export const clientID: { id: string, value: string } = {
   id: 'client_id',
   value: 'Iv23li0Pvl3E4crXIBQ0',
 };
+
+export const serverURL: { id: string, value: string } = {
+  id: 'server_url',
+  value: 'http://localhost:1234/',
+};

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -65,15 +65,12 @@ export function getAndValidateParameterValues(url: string): 'invalidParams' | 'r
 
   // Return the status string for the notifications
   if (hasMissingReferer) {
-    console.log('hasMissingReferer')
     return 'refererMissing';
   }
 
   if (hasMissingValues || hasInvalidParams) {
-    console.log('invalidParams')
     return 'invalidParams';
   }
-  console.log('parameters:', parameters)
   return parameters;
 }
 

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -16,7 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { showToast } from './toast';
-import { clientID } from '../config';
+import { clientID, serverURL } from '../config';
 import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
 /**
@@ -35,7 +35,7 @@ export const validKeys = ['ghrepo', 'source', 'referer'];
  * @param url - URL string
  * @returns An array with key-value objects of the URL parameter values or a status string for handling the notifications
  */
-export function getAndValidateParameterValues(url: string): 'invalidParams' | 'noParams' | { key: string, value: string }[] {
+export function getAndValidateParameterValues(url: string): 'invalidParams' | 'refererMissing' | 'noParams' | { key: string, value: string }[] {
   const parameters: { key: string, value: string }[] = [];
 
   const urlParts = url.split('?');
@@ -58,14 +58,22 @@ export function getAndValidateParameterValues(url: string): 'invalidParams' | 'n
     }
   }
 
+  // Check if referer parameter is missing
+  const hasMissingReferer = !params.has('referer');
   const hasMissingValues = parameters.some(({ value }) => value === null || value === '');
   const hasInvalidParams = validKeys.some(key => !params.has(key));
 
   // Return the status string for the notifications
-  if (hasMissingValues || hasInvalidParams) {
-    return 'invalidParams';
+  if (hasMissingReferer) {
+    console.log('hasMissingReferer')
+    return 'refererMissing';
   }
 
+  if (hasMissingValues || hasInvalidParams) {
+    console.log('invalidParams')
+    return 'invalidParams';
+  }
+  console.log('parameters:', parameters)
   return parameters;
 }
 
@@ -89,11 +97,13 @@ export function isOAuthCodeParam(key: string): boolean {
  *
  * @param parameters - The URL parameters
  */
-export function showNotification(parameters: 'authenticated' | 'invalidParams' | 'noParams' | { key: string, value: string }[]): void {
+export function showNotification(parameters: 'authenticated' | 'invalidParams' | 'noParams' | 'refererMissing' |{ key: string, value: string }[]): void {
   if (typeof parameters === 'object') {
     showToast('Success! You will be redirected to GitHub OAuth', 'success');
   } else if (parameters === 'invalidParams') {
     showToast('Your request is invalid.', 'error');
+  } else if (parameters === 'refererMissing') {
+    showToast('Missing referer parameter.', 'error');
   } else if (parameters === 'noParams') {
     showToast('Welcome to the Petal Demo Website.', 'info');
   } else if(parameters === 'authenticated') {
@@ -101,13 +111,45 @@ export function showNotification(parameters: 'authenticated' | 'invalidParams' |
   }
 }
 
-
 /**
  * Redirects the user to GitHub OAuth
  */
 export function redirectToGitHubOAuth(): void {
   const { id, value } = clientID;
   window.location.href = 'https://github.com/login/oauth/authorize?' + id + '=' + value;
+}
+
+/**
+ * Redirects the user to the referer parameter from URL params
+ */
+export function handleInvalidRequest(): void {
+  const userParamsString = localStorage.getItem('userParams');
+  if (userParamsString) {
+    const userParams = JSON.parse(userParamsString);
+    const storedReferer = userParams.find((item: { key: string; }) => item.key === 'referer')?.value;
+    if (storedReferer) {
+      window.location.href = storedReferer;
+    } else {
+      // If the 'referer' key is not found in userParams, show error page
+      window.location.href = serverURL.value + 'auth-error.html';
+    }
+
+  } else {
+    // Send back to referer parameter from URL params
+    const referer = new URLSearchParams(window.location.search).get('referer');
+    if (referer) {
+      window.location.href = referer;
+    } else {
+      window.location.href = serverURL.value + 'auth-error.html';
+    }
+  }
+}
+
+/**
+ * Redirects the user to the error page
+ */
+export function showErrorPage(): void {
+  window.location.href = serverURL.value + 'auth-error.html';
 }
 
 /**
@@ -122,9 +164,11 @@ export function processRequest(): undefined | { key: string, value: string }[] {
       const parameters = getAndValidateParameterValues(currentUrl);
 
       if (typeof parameters === 'string') {
-        if(parameters === 'invalidParams') {
-          //TODO(YB): Redirect to referer if it exists
-          //TODO(YB): Redirect to Petal error page if referer doesn't exist
+        if (parameters === 'invalidParams') {
+          handleInvalidRequest();
+        }
+        if (parameters === 'refererMissing') {
+          showErrorPage();
         }
         showNotification(parameters);
 
@@ -140,9 +184,8 @@ export function processRequest(): undefined | { key: string, value: string }[] {
         //TODO(YB): These Params should passed with the OAuth redirect URL
         // get the stored parameters from localStorage
         const storedParams = localStorage.getItem('userParams');
-        if(!storedParams) {
-          // TODO: Redirect to Petal error page
-          // we should never reach here
+        if (!storedParams) {
+          showErrorPage();
           return undefined;
         }
         // in case of an error, the user did not authenticate the app
@@ -156,10 +199,8 @@ export function processRequest(): undefined | { key: string, value: string }[] {
         // exchange the code for an access token
         const codeParam = parameters.find(param => param.key === 'code');
         if (!codeParam) return undefined; // I don't understand why this is necessary as the previous if statement should have caught this
-        const code = codeParam.value;
-
-
-        exchangeOAuthCodeForAccessToken(code).then(token => {
+          const code = codeParam.value;
+          exchangeOAuthCodeForAccessToken(code).then(token => {
           localStorage.setItem('token', token);
         }).catch(e => {
           console.error(e);

--- a/packages/prosemirror-lwdita/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/tests/request.spec.ts
@@ -47,17 +47,17 @@ describe('When function getParameterValues() is passed a URL with', () => {
 
   it('one valid parameter, but the rest is missing, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo=xyz';
-    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('refererMissing');
   });
 
   it('two missing parameters, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo';
-    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('refererMissing');
   });
 
   it('any parameter that is not matching any of the expected keys, it returns string "invalidParams"', () => {
     invalidUrl = url + '?xyz';
-    expect(getAndValidateParameterValues(invalidUrl)).to.equal('invalidParams');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('refererMissing');
   });
 
   it('no parameters at all, it returns string "noParams"', () => {


### PR DESCRIPTION
### Description

This PR handles errors during requests depending on the error case and provides feeback to users and redirects to the referrer page, or shows a Petal error page, if no referer parameter has been received or has been stored.

### How to test this PR

1. Insert different parameters to test all cases.
2. Manipulate the localStorage in the browser devTools: Delete a key, a value to also test if all checks have been implemented correctly.
