### PR TITLE
Display a dismissible welcome note on page load

### DIFF
--- a/packages/prosemirror-lwdita-demo/cypress/e2e/image.cy.ts
+++ b/packages/prosemirror-lwdita-demo/cypress/e2e/image.cy.ts
@@ -1,15 +1,19 @@
 describe('handling images', () => {
   beforeEach(() => {
     window.localStorage.setItem('file', `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
-<topic id="program">
-  <title>Test File 2</title>
-  <body>
-    <section>
-      <p>A test paragraph.</p>
-    </section>
-  </body>
-</topic>`);
+    <!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
+    <topic id="program">
+      <title>Test File 2</title>
+      <body>
+        <section>
+          <p>A test paragraph.</p>
+        </section>
+      </body>
+    </topic>`);
+
+    // set the welcome note as confirmed to not show it on page load
+    // because it will cover the test target in the editor
+    window.localStorage.setItem('welcomeNoteConfirmed', 'true');
   })
 
   it('inserting remote image using the toolbar button', () => {

--- a/packages/prosemirror-lwdita-demo/cypress/e2e/welcome-note.cy.ts
+++ b/packages/prosemirror-lwdita-demo/cypress/e2e/welcome-note.cy.ts
@@ -1,0 +1,78 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+function clearLocalStorage() {
+  window.localStorage.clear();
+}
+
+describe('The Welcome note:', () => {
+  let loadPage,
+      note,
+      noteSelector,
+      dismissButton,
+      dismissSelector,
+      crossIconSelector;
+
+  beforeEach(() => {
+    loadPage = cy.visit('http://localhost:1234/');
+    noteSelector = '.toast--welcome';
+    dismissSelector = '.toast--dismiss';
+    crossIconSelector = '.toast-close';
+  })
+
+  describe('When a user opens Petal for the first time', () => {
+    beforeEach(() => {
+      note = loadPage.get(noteSelector);
+    })
+
+    it('a "welcome" note will be displayed on page load', () => {
+      note.should('be.visible');
+    });
+  });
+
+  describe('When the user clicks on the dismiss button', () => {
+    beforeEach(() => {
+      note = loadPage.get(noteSelector);
+      dismissButton = note.find(dismissSelector);
+      dismissButton.click();
+    })
+
+    it('the note will be dismissed', () => {
+      note.should('not.exist');
+    });
+
+    it('the note will be will not be shown on next visit', () => {
+      note.should('not.exist');
+    });
+  });
+
+  describe('When the user clicks on the cross icon button', () => {
+    beforeEach(() => {
+      clearLocalStorage();
+      note = loadPage.get(noteSelector);
+      dismissButton = note.find(crossIconSelector);
+      dismissButton.click();
+    })
+
+    it('the note will be shown again on the next visit', () => {
+      note.should('be.visible');
+    });
+  });
+});
+
+
+

--- a/packages/prosemirror-lwdita-demo/cypress/e2e/welcome-note.cy.ts
+++ b/packages/prosemirror-lwdita-demo/cypress/e2e/welcome-note.cy.ts
@@ -20,12 +20,12 @@ function clearLocalStorage() {
 }
 
 describe('The Welcome note:', () => {
-  let loadPage,
-      note,
-      noteSelector,
-      dismissButton,
-      dismissSelector,
-      crossIconSelector;
+  let loadPage: Cypress.Chainable<Cypress.AUTWindow>,
+      note: { should: (arg0: string) => void; find: (arg0: any) => any; },
+      noteSelector: string,
+      dismissButton: { click: () => void; },
+      dismissSelector: string,
+      crossIconSelector: string;
 
   beforeEach(() => {
     loadPage = cy.visit('http://localhost:1234/');

--- a/packages/prosemirror-lwdita-demo/cypress/e2e/welcome-note.cy.ts
+++ b/packages/prosemirror-lwdita-demo/cypress/e2e/welcome-note.cy.ts
@@ -21,6 +21,7 @@ function clearLocalStorage() {
 
 describe('The Welcome note:', () => {
   let loadPage: Cypress.Chainable<Cypress.AUTWindow>,
+      // TODO (A.): Add documentation
       note: { should: (arg0: string) => void; find: (arg0: any) => any; },
       noteSelector: string,
       dismissButton: { click: () => void; },

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -1,7 +1,7 @@
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { Node } from "prosemirror-model";
-import { schema } from "@evolvedbinary/prosemirror-lwdita";
+import { hasConfirmedNotification, schema, showWelcomeNote } from "@evolvedbinary/prosemirror-lwdita";
 import jsonDocLoader from "./doc";
 import { menu, shortcuts } from "@evolvedbinary/prosemirror-lwdita";
 import { githubMenuItem, openFileMenuItem, publishFileMenuItem, saveFileMenuItem} from "./demo-plugin";
@@ -9,6 +9,13 @@ import { history } from "prosemirror-history";
 import { doubleClickImagePlugin, processRequest, fetchAndTransform, URLParams } from '@evolvedbinary/prosemirror-lwdita'
 
 const schemaObject = schema();
+
+
+// Check if the "welcome" note has not yet been dismissed
+// and show it on page load
+if (!hasConfirmedNotification()) {
+  showWelcomeNote();
+}
 
 /**
  * Process the URL parameters and handle the notifications

--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -531,7 +531,31 @@ button {
   &--info {
     background-color: #00bcd4;
   }
+  &--welcome {
+    background-color: #1c3f7c; // EB blue
+    padding: 1.5rem 2.5rem 2rem 2.5rem;
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: flex-end;
+    top: 75px !important;
+    width: 22rem;
+
+    // Customized toastify-right behavior: Reset position
+    &.toastify-right{
+      right: 0 !important;
+    }
+  }
+  &--dismiss {
+    @extend .pt__button;
+    font-family: inherit;
+    padding: .5rem;
+    margin: 0.3rem 0 0 0;
+  }
+  &-close {
+    flex: 0 2rem;
+  }
 }
+
 
 @media only screen and (max-width: 360px) {
 

--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -1,5 +1,7 @@
 $nodes: "audio", "body", "data", "dd", "desc", "dl", "dlentry", "dt", "document", "fig", "fn", "image", "media-source", "media-track", "li", "note", "ol", "p", "ph", "pre", "prolog", "section", "simpletable", "shortdesc", "stentry", "sthead", "strow", "title", "topic", "ul", "video", "xref", "b", "i", "u", "sub", "sup";
-$height: 36px;
+$toolbar-height: 36px;
+$header-height: 50px;
+$header-padding-top: 12px;
 
 html {
   height: 100%;
@@ -42,7 +44,8 @@ body {
     .header {
       color: white;
       background-color: #f16999;
-      padding: 12px 24px;
+      padding: $header-padding-top 24px;
+      height: $header-height;
       h1 {
         display: inline;
         margin: 0;
@@ -106,9 +109,9 @@ body {
             }
             & > * {
               cursor: pointer;
-              line-height: $height;
-              height: $height;
-              min-width: $height;
+              line-height: $toolbar-height;
+              height: $toolbar-height;
+              min-width: $toolbar-height;
               white-space: nowrap;
               &.separator {
                 min-width: auto;
@@ -170,7 +173,7 @@ body {
                 left: 0;
                 right: 0;
                 bottom: 0;
-                height: $height;
+                height: $toolbar-height;
 
                 &[type="button"] {
                   appearance: none;
@@ -189,7 +192,7 @@ body {
           .ProseMirror-menuseparator {
             background-color: #c8c8c8;
             width: 1px;
-            height: $height - 8px;
+            height: $toolbar-height - 8px;
             margin: 0 12px;
           }
         }
@@ -537,7 +540,7 @@ button {
     display: flex;
     flex-direction: column-reverse;
     align-items: flex-end;
-    top: 75px !important;
+    top: $header-height + $toolbar-height + calc(2* $header-padding-top) !important; // Shift note below header and toolbar
     width: 22rem;
 
     // Customized toastify-right behavior: Reset position

--- a/packages/prosemirror-lwdita/src/config.ts
+++ b/packages/prosemirror-lwdita/src/config.ts
@@ -24,3 +24,15 @@ export const serverURL: { id: string, value: string } = {
   id: 'server_url',
   value: 'http://localhost:1234/',
 };
+
+/**
+ * Store all messages strings for the application
+ */
+export const messageKeys = {
+  welcomeNote : {
+    title: "Welcome to the Petal Editor.",
+    paragraph1: "You can edit the file and publish your changes by clicking the 'Publish File' button.",
+    paragraph2: "Your changes will be published to GitHub in your GitHub repository. After successful publication you will notified with a link to the PR. Happy editing!",
+    buttonLabel: "Don't show again",
+  },
+}

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -15,8 +15,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { showToast } from './toast';
-import { clientID, serverURL } from '../config';
+import { hasConfirmedNotification, showToast, showWelcomeNote } from './toast';
+import { clientID, serverURL, messageKeys } from '../config';
 import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
 /**
@@ -108,8 +108,6 @@ export function showNotification(parameters: 'authenticated' | 'invalidParams' |
     showToast('Your request is invalid.', 'error');
   } else if (parameters === 'refererMissing') {
     showToast('Missing referer parameter.', 'error');
-  } else if (parameters === 'noParams') {
-    showToast('Welcome to the Petal Demo Website.', 'info');
   } else if(parameters === 'authenticated') {
     showToast('You are authenticated.', 'success');
   }
@@ -166,6 +164,12 @@ export function processRequest(): undefined | URLParams {
 
     try {
       const parameters = getAndValidateParameterValues(currentUrl);
+
+      // Check if the "welcome" note has not yet been dismissed
+      // and show it on page load
+      if (!hasConfirmedNotification()) {
+        showWelcomeNote();
+      }
 
       if (typeof parameters === 'string') {
         if (parameters === 'invalidParams') {

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -16,7 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { hasConfirmedNotification, showToast, showWelcomeNote } from './toast';
-import { clientID, serverURL, messageKeys } from '../config';
+import { clientID, serverURL } from '../config';
 import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
 /**

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { hasConfirmedNotification, showToast, showWelcomeNote } from './toast';
+import { showToast } from './toast';
 import { clientID, serverURL } from '../config';
 import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
@@ -164,12 +164,6 @@ export function processRequest(): undefined | URLParams {
 
     try {
       const parameters = getAndValidateParameterValues(currentUrl);
-
-      // Check if the "welcome" note has not yet been dismissed
-      // and show it on page load
-      if (!hasConfirmedNotification()) {
-        showWelcomeNote();
-      }
 
       if (typeof parameters === 'string') {
         if (parameters === 'invalidParams') {

--- a/packages/prosemirror-lwdita/src/github-integration/toast.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/toast.ts
@@ -17,7 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import Toastify from 'toastify-js';
+import Toastify, { Options } from 'toastify-js';
+import { messageKeys } from '../config';
 
 /**
  * Displays a toast message with 'Toastify' library
@@ -33,4 +34,48 @@ export function showToast(message: string, type: 'success' | 'error' | 'warning'
     position: 'right',
     className: `toast toast--${type}`,
   }).showToast();
+}
+
+/**
+ * Displays a customized Tostify message
+ * with customized markup
+ * that users can confirm to never show again
+ * by storing it in the localStorage
+ */
+export const showWelcomeNote = () => {
+  const customNote = document.createElement('section');
+  customNote.innerHTML = `
+  <h2>${messageKeys.welcomeNote.title}</h2>
+  <p>${messageKeys.welcomeNote.paragraph1}</p>
+  <p>${messageKeys.welcomeNote.paragraph2}</p>
+  <button type="button" class="toast--dismiss">${messageKeys.welcomeNote.buttonLabel}</button>
+  `;
+
+  const parentNode = document.body;
+  parentNode.appendChild(customNote);
+
+  Toastify({
+    text: '',
+    duration: -1,
+    gravity: 'top',
+    position: 'right',
+    className: 'toast toast--welcome',
+    close: true,
+    node: customNote,
+    onClick: function () {
+      const toastElement = document.querySelector('.toast--welcome');
+      if (toastElement) {
+        toastElement.remove();
+        localStorage.setItem('welcomeNoteConfirmed', 'true');
+      }
+    }
+  }).showToast();
+};
+
+/**
+ * Checks if the welcome note has been confirmed
+ * @returns True if the welcome note has been confirmed
+ */
+export function hasConfirmedNotification(): boolean {
+  return localStorage.getItem('welcomeNoteConfirmed') === 'true';
 }


### PR DESCRIPTION
### Description

This PR creates a welcome not on each page load, until the user dismisses the note.

* create custom markup for toastify-js toast
* create custom styling for toast
* create object messageKeys to store, read and maintain content strings in a config file
* store key `welcomeNoteConfirmed` in localStorage if user clicks dismiss button and check on page load if key exists
* remove obsolete toast for case `noParams`
* add option `close: true` to toast for removing the toast only for this session without storing the key into localStorage

<img width="509" alt="Screenshot 2024-09-25 at 13 15 31" src="https://github.com/user-attachments/assets/dfd6f33c-121b-4bf2-91dd-4848848f01b8">


### How to test this PR

1. Install the branch
2. Start the demo `yarn start:demo`
3. Load the page
4. Test to click on the message or the dismiss button and check the localStorage for key `welcomeNoteConfirmed` in the devTools. It should be stored there.
5. Reload the page - the note should not turn up.
6. Clear the localStorage key `welcomeNoteConfirmed`.
7. Reload the page and check again by clicking on the cross icon - the localStorage should not contain key `welcomeNoteConfirmed` and the note should be visible again. 