### PR TITLE
Show user notifications for final result after publication

### DIFF
--- a/packages/prosemirror-lwdita-demo/style/style.scss
+++ b/packages/prosemirror-lwdita-demo/style/style.scss
@@ -1,7 +1,7 @@
 $nodes: "audio", "body", "data", "dd", "desc", "dl", "dlentry", "dt", "document", "fig", "fn", "image", "media-source", "media-track", "li", "note", "ol", "p", "ph", "pre", "prolog", "section", "simpletable", "shortdesc", "stentry", "sthead", "strow", "title", "topic", "ul", "video", "xref", "b", "i", "u", "sub", "sup";
 $toolbar-height: 36px;
 $header-height: 50px;
-$header-padding-top: 12px;
+$header-padding-top: 10px;
 
 html {
   height: 100%;
@@ -467,6 +467,11 @@ button {
   text-decoration: none;
   max-width: calc(50% - 20px);
   z-index: 2147483647;
+
+  // Customize links
+  a {
+    color: inherit;
+  }
 }
 
 .toastify.on {
@@ -524,18 +529,24 @@ button {
 .toast {
   &--success {
     background-color: #4caf50;
+    color: #ffffff;
   }
   &--error {
-    background-color: #f44336;
+    background-color: #a5395e;
+    color: #ffffff;
   }
   &--warning {
     background-color: #ff9800;
   }
   &--info {
-    background-color: #00bcd4;
+    background-color: #00bcd4; // EB light blue
   }
   &--welcome {
     background-color: #1c3f7c; // EB blue
+    color: #ffffff
+  }
+
+  &__panel {
     padding: 1.5rem 2.5rem 2rem 2.5rem;
     display: flex;
     flex-direction: column-reverse;
@@ -544,10 +555,11 @@ button {
     width: 22rem;
 
     // Customized toastify-right behavior: Reset position
-    &.toastify-right{
+    &.toastify-right {
       right: 0 !important;
     }
   }
+
   &--dismiss {
     @extend .pt__button;
     font-family: inherit;

--- a/packages/prosemirror-lwdita/src/app-config.ts
+++ b/packages/prosemirror-lwdita/src/app-config.ts
@@ -38,7 +38,7 @@ export const messageKeys = {
   resultNote: {
     titleSuccess: "Your changes have been successfully published.",
     titleError: "Your changes could not be published.",
-    paragraphSuccess: "You can visit this link to see the PR: ",
-    paragraphError: "Something went wrong with publishing your PR because of following error:",
+    paragraphSuccess: "You can check your published changes here: ",
+    paragraphError: "Something went wrong with publishing your changes because of following error:",
   },
 }

--- a/packages/prosemirror-lwdita/src/commands.ts
+++ b/packages/prosemirror-lwdita/src/commands.ts
@@ -21,6 +21,7 @@ import { chainCommands } from 'prosemirror-commands';
 import { Fragment, MarkType, Node, NodeType, ResolvedPos } from 'prosemirror-model';
 import { Command, EditorState, TextSelection, Transaction } from 'prosemirror-state';
 import { createPrFromContribution } from './github-integration/github.plugin';
+import { showResultStatusError, showResultStatusSuccess } from './github-integration/toast';
 
 /**
  * Create a new Node and fill it with the args as attributes.
@@ -245,12 +246,12 @@ export function renderPrDialog(ghrepo: string, source: string, updatedXdita: str
       .then((prURL: string) => {
         console.log('The document has been published to GitHub.');
         console.log('pr url:', prURL);
-        // show a toast notification
         // show success dialog
+        showResultStatusSuccess(prURL, prURL)
       }).catch((error: Error) => {
         console.error('Error:', error);
-        // show a toast notification
         // show error dialog
+        showResultStatusError(error.message)
       });
 
       document.body.removeChild(overlay);

--- a/packages/prosemirror-lwdita/src/commands.ts
+++ b/packages/prosemirror-lwdita/src/commands.ts
@@ -21,7 +21,7 @@ import { chainCommands } from 'prosemirror-commands';
 import { Fragment, MarkType, Node, NodeType, ResolvedPos } from 'prosemirror-model';
 import { Command, EditorState, TextSelection, Transaction } from 'prosemirror-state';
 import { createPrFromContribution } from './github-integration/github.plugin';
-import { showResultStatusError, showResultStatusSuccess } from './github-integration/toast';
+import { showPublicationResultError, showPublicationResultSuccess } from './github-integration/toast';
 
 /**
  * Create a new Node and fill it with the args as attributes.
@@ -237,21 +237,17 @@ export function renderPrDialog(ghrepo: string, source: string, updatedXdita: str
       const title = titleInput.value;
       const description = descField.value;
 
-      // Start the API request here
-      console.log('Title:', title);
-      console.log('Description:', description);
-
       // Create a PR from the contribution
       createPrFromContribution(ghrepo, source, updatedXdita, title, description)
       .then((prURL: string) => {
         console.log('The document has been published to GitHub.');
         console.log('pr url:', prURL);
-        // show success dialog
-        showResultStatusSuccess(prURL, prURL)
+        // Show a user notification with the successful result and a link to the PR
+        showPublicationResultSuccess(prURL)
       }).catch((error: Error) => {
         console.error('Error:', error);
         // show error dialog
-        showResultStatusError(error.message)
+        showPublicationResultError(error.message)
       });
 
       document.body.removeChild(overlay);

--- a/packages/prosemirror-lwdita/src/config.ts
+++ b/packages/prosemirror-lwdita/src/config.ts
@@ -35,4 +35,10 @@ export const messageKeys = {
     paragraph2: "Your changes will be published to GitHub in your GitHub repository. After successful publication you will notified with a link to the PR. Happy editing!",
     buttonLabel: "Don't show again",
   },
+  resultNote: {
+    titleSuccess: "Your changes have been successfully published.",
+    titleError: "Your changes could not be published.",
+    paragraphSuccess: "You can visit this link to see the PR: ",
+    paragraphError: "Something went wrong with publishing your PR because of following error:",
+  },
 }

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -16,7 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { showToast } from './toast';
-import { clientID, serverURL } from '../config';
+import { clientID, serverURL } from '../app-config';
 import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
 /**

--- a/packages/prosemirror-lwdita/src/github-integration/toast.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/toast.ts
@@ -79,3 +79,48 @@ export const showWelcomeNote = () => {
 export function hasConfirmedNotification(): boolean {
   return localStorage.getItem('welcomeNoteConfirmed') === 'true';
 }
+
+export function showResultStatusSuccess(destination: string, linkToPR: string) {
+  const customNote = document.createElement('section');
+  customNote.innerHTML = `
+  <h2>${messageKeys.resultNote.titleSuccess}</h2>
+  <p>${messageKeys.resultNote.paragraphSuccess}</p>
+  <a href="${linkToPR}">${linkToPR}</a>
+  `;
+
+  const parentNode = document.body;
+  parentNode.appendChild(customNote);
+
+  Toastify({
+    text: '',
+    duration: -1,
+    gravity: 'top',
+    position: 'right',
+    className: `toast__status toast--success`,
+    close: true,
+    destination: destination,
+    newWindow: true,
+    node: customNote,
+  }).showToast();
+}
+
+export function showResultStatusError(message: string) {
+  const customNote = document.createElement('section');
+  customNote.innerHTML = `
+  <h2>${messageKeys.resultNote.titleError}</h2>
+  <p>${messageKeys.resultNote.paragraphError}</p>
+  <p>${message}</p>`;
+
+  const parentNode = document.body;
+  parentNode.appendChild(customNote);
+
+  Toastify({
+    text: message,
+    duration: -1,
+    gravity: 'top',
+    position: 'right',
+    className: `toast__status toast--error`,
+    close: true,
+    node: customNote,
+  }).showToast();
+}

--- a/packages/prosemirror-lwdita/src/github-integration/toast.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/toast.ts
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import Toastify, { Options } from 'toastify-js';
-import { messageKeys } from '../config';
+import { messageKeys } from '../app-config';
 
 /**
  * Displays a toast message with 'Toastify' library

--- a/packages/prosemirror-lwdita/src/github-integration/toast.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/toast.ts
@@ -59,7 +59,7 @@ export const showWelcomeNote = () => {
     duration: -1,
     gravity: 'top',
     position: 'right',
-    className: 'toast toast--welcome',
+    className: 'toast toast__panel toast--welcome',
     close: true,
     node: customNote,
     onClick: function () {
@@ -101,7 +101,7 @@ export function showPublicationResultSuccess(destination: string) {
     duration: -1,
     gravity: 'top',
     position: 'right',
-    className: `toast__status toast--success`,
+    className: `toast__panel toast--success`,
     close: true,
     destination: destination,
     newWindow: true,

--- a/packages/prosemirror-lwdita/src/github-integration/toast.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/toast.ts
@@ -80,12 +80,17 @@ export function hasConfirmedNotification(): boolean {
   return localStorage.getItem('welcomeNoteConfirmed') === 'true';
 }
 
-export function showResultStatusSuccess(destination: string, linkToPR: string) {
+/**
+ * Shows a user notification containing a custom,
+ * static message and a dynamic link
+ * @param destination - URL to which the browser should be navigated on click of the toast
+ */
+export function showPublicationResultSuccess(destination: string) {
   const customNote = document.createElement('section');
   customNote.innerHTML = `
   <h2>${messageKeys.resultNote.titleSuccess}</h2>
   <p>${messageKeys.resultNote.paragraphSuccess}</p>
-  <a href="${linkToPR}">${linkToPR}</a>
+  <a href="${destination}"></span>${destination}</a>
   `;
 
   const parentNode = document.body;
@@ -104,7 +109,11 @@ export function showResultStatusSuccess(destination: string, linkToPR: string) {
   }).showToast();
 }
 
-export function showResultStatusError(message: string) {
+/**
+ * Shows a user notification containing a dynamic message
+ * @param message - Error message
+ */
+export function showPublicationResultError(message: string) {
   const customNote = document.createElement('section');
   customNote.innerHTML = `
   <h2>${messageKeys.resultNote.titleError}</h2>
@@ -119,7 +128,7 @@ export function showResultStatusError(message: string) {
     duration: -1,
     gravity: 'top',
     position: 'right',
-    className: `toast__status toast--error`,
+    className: `toast__panel toast--error`,
     close: true,
     node: customNote,
   }).showToast();


### PR DESCRIPTION
### Description

This PR adds 2 new toast types: 
1. A panel-layout notification that stays until dismissed, contains a static message text, and a link to a url passed as an argument. This will be used for success messages after publication.
2. A panel-layout notification that stays until dismissed, contains a static message text, and an error message passed as an argument. This will be used for error messages after publication.

<img width="480" alt="Screenshot 2024-09-26 at 12 37 01" src="https://github.com/user-attachments/assets/c827ae58-7642-45e7-b18a-a7514efe59a2">


<img width="484" alt="Screenshot 2024-09-26 at 12 37 53" src="https://github.com/user-attachments/assets/d0f6824d-b30d-48eb-aef8-f26d312b8d79">


### How to test this PR

1. Install and build the branch.
2. Test the toasts: 
    - Either run the entire publication process with running the local server
    - or call the toast functions `showPublicationResultSuccess(<insert a GitHub URL>)`, `showPublicationResultError(<insert a static string>)` in example.ts on page load, but mind that the welcome note will cover the toasts on the first load. You have to pass a link / a Message to the functions.