### PR TITLE
Encode user params in the oauth url

### DIFF
--- a/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
+++ b/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
@@ -72,6 +72,7 @@ export const getUserInformation = async (req: Request, res: Response) => {
  * - `repo: string` - The name of the repository where the changes are made.
  * - `newOwner: string` - The owner of the fork where the new branch is created (can be the same as the original owner).
  * - `newBranch: string` - The name of the new branch where the commit will be applied.
+ * - `branch: string` - The name of the base branch.
  * - `commitMessage: string` - A message describing the changes in the commit.
  * - `change: { path: string, content: string }` - An object describing the file change:
  *   - `path: string` - The file path in the repository to be modified.
@@ -96,8 +97,8 @@ export const commitChangesAndCreatePR = async (req: Request, res: Response) => {
   }
 
   //TODO(YB): Add validation
-  const { owner, repo, newOwner, newBranch, commitMessage, change, title, body } = req.body;
-  if(!owner || !repo || !newOwner || !newBranch || !commitMessage || !change || !title || !body) {
+  const { owner, repo, newOwner, branch, newBranch, commitMessage, change, title, body } = req.body;
+  if(!owner || !repo || !newOwner || !branch || !newBranch || !commitMessage || !change || !title || !body) {
     return res.status(400).json({ error: 'Bad Request : Invalid argument' });
   }
 
@@ -111,7 +112,7 @@ export const commitChangesAndCreatePR = async (req: Request, res: Response) => {
     auth: token,
   });
 
-  const response = await pushChangesAndCreatePullRequest(octokit, owner, repo, newOwner, newBranch, commitMessage, change, title, body);
+  const response = await pushChangesAndCreatePullRequest(octokit, owner, repo, newOwner, branch, newBranch, commitMessage, change, title, body);
 
   res.json(response);
 };

--- a/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
+++ b/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
@@ -105,7 +105,6 @@ const createFork = async (octokit: Octokit, owner: string, repo: string): Promis
     const response = await octokit.repos.createFork({
       owner,
       repo,
-      default_branch_only: true, // fork only the default branch
     });
 
     return response.data.html_url;
@@ -123,7 +122,7 @@ const createFork = async (octokit: Octokit, owner: string, repo: string): Promis
  * @param newBranch - The name of the new branch to be created.
  * @returns A Promise that resolves to a BranchInfo object representing the newly created branch, or undefined if an error occurs.
  */
-const createBranch = async (octokit: Octokit, owner: string, repo: string, newBranch: string): Promise<BranchInfo | undefined> => {
+const createBranch = async (octokit: Octokit, owner: string, repo: string, branch: string, newBranch: string): Promise<BranchInfo | undefined> => {
   try {
     // get the repo data
     const { data: repoData } = await octokit.repos.get({
@@ -131,16 +130,11 @@ const createBranch = async (octokit: Octokit, owner: string, repo: string, newBr
       repo,
     });
 
-    // get the default branch
-    // there's an existing issue with the github API where the default branch is returned as 'master' instead of 'main'
-    //TODO(YB): Ask the GitHub API team to fix this issue
-    const defaultBranch = repoData.default_branch === 'master'? 'main' : repoData.default_branch; 
-
     // get the default branch ref
     const { data: branchData } = await octokit.repos.getBranch({
       owner,
       repo,
-      branch: defaultBranch,
+      branch: branch,
     });
 
     // get the last commit sha
@@ -156,7 +150,7 @@ const createBranch = async (octokit: Octokit, owner: string, repo: string, newBr
     });
 
     return {
-      defaultBranch: defaultBranch,
+      defaultBranch: branch,
       commit: {
         sha: lastCommitSha,
         treeSha: branchData.commit.commit.tree.sha,
@@ -282,7 +276,7 @@ const createPullRequest = async (octokit: Octokit, owner: string, repo: string, 
  * @param body - The body of the pull request.
  * @returns The URL of the created pull request, or undefined if an error occurred.
  */
-export const pushChangesAndCreatePullRequest = async (octokit: Octokit, owner: string, repo: string, newOwner:string, newBranch: string, commitMessage: string, change: { path: string, content: string }, title: string, body: string): Promise<string | undefined> => {
+export const pushChangesAndCreatePullRequest = async (octokit: Octokit, owner: string, repo: string, newOwner:string, branch: string, newBranch: string, commitMessage: string, change: { path: string, content: string }, title: string, body: string): Promise<string | undefined> => {
   try {
     // create a fork
     const forkUrl = await createFork(octokit, owner, repo);
@@ -290,13 +284,12 @@ export const pushChangesAndCreatePullRequest = async (octokit: Octokit, owner: s
       throw new Error("Error during fork creation");
     }
     // create a new branch
-    const branch = await createBranch(octokit, newOwner, repo, newBranch);
-    if(!branch) {
+    const createdBranch = await createBranch(octokit, newOwner, repo, branch, newBranch);
+    if(!createdBranch) {
       throw new Error("Error during branch creation");
     }
-    const defaultBranch = branch.defaultBranch;
     // commit the changes
-    const commit = await commitChanges(octokit, newOwner, repo, newBranch, branch.commit, commitMessage, change);
+    const commit = await commitChanges(octokit, newOwner, repo, newBranch, createdBranch.commit, commitMessage, change);
     if(!commit) {
       throw new Error("Error during commit");
     }
@@ -304,7 +297,7 @@ export const pushChangesAndCreatePullRequest = async (octokit: Octokit, owner: s
     // the PR will be opened from the new branch to the default branch
     const head = `${newOwner}:${newBranch}`;
     // create a pull request
-    const pullRequestUrl = await createPullRequest(octokit, newOwner, repo, defaultBranch, head, title, body);
+    const pullRequestUrl = await createPullRequest(octokit, newOwner, repo, branch, head, title, body);
     if(!pullRequestUrl) {
       throw new Error("Error during pull request creation");
     }

--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -144,7 +144,7 @@ function publishGithubDocument(urlParams: URLParams): Command {
 
 
       // show the publishing dialog
-      renderPrDialog(urlParams.ghrepo, urlParams.source, updatedXdita);
+      renderPrDialog(urlParams.ghrepo, urlParams.source, urlParams.branch, updatedXdita);
     } else {
       console.log('Nothing to publish, no EditorState has been dispatched.');
     }

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -10,7 +10,6 @@ import { doubleClickImagePlugin, processRequest, fetchAndTransform, URLParams } 
 
 const schemaObject = schema();
 
-
 // Check if the "welcome" note has not yet been dismissed
 // and show it on page load
 if (!hasConfirmedNotification()) {

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -26,7 +26,7 @@ const urlParams = processRequest() as URLParams | undefined;
 let loadJsonDoc = jsonDocLoader;
 if(urlParams) {
   // create a new promise to fetch the raw document from GitHub then transform it to ProseMirror JSON
-  loadJsonDoc = fetchAndTransform(urlParams.ghrepo, urlParams.source);
+  loadJsonDoc = fetchAndTransform(urlParams.ghrepo, urlParams.source, urlParams.branch);
 }
 
 /**

--- a/packages/prosemirror-lwdita/src/commands.ts
+++ b/packages/prosemirror-lwdita/src/commands.ts
@@ -181,7 +181,7 @@ export class InputContainer {
 /**
  * Render a dialog form for inserting the PR metadata
  */
-export function renderPrDialog(ghrepo: string, source: string, updatedXdita: string): void {
+export function renderPrDialog(ghrepo: string, source: string, branch: string, updatedXdita: string): void {
   const overlay = document.createElement('section');
   overlay.id = 'prOverlay';
   document.body.appendChild(overlay);
@@ -241,7 +241,7 @@ export function renderPrDialog(ghrepo: string, source: string, updatedXdita: str
       console.log('Description:', description);
 
       // Create a PR from the contribution
-      createPrFromContribution(ghrepo, source, updatedXdita, title, description)
+      createPrFromContribution(ghrepo, source, branch, updatedXdita, title, description)
       .then((prURL: string) => {
         console.log('The document has been published to GitHub.');
         console.log('pr url:', prURL);

--- a/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
@@ -113,13 +113,13 @@ export const getUserInfo = async (token: string): Promise<Record<string, string>
  * @param changedDocument - The content of the changed document.
  * @returns A promise that resolves when the document has been published.
  */
-export const createPrFromContribution = async (ghrepo: string, source: string, changedDocument: string, title: string, desc: string): Promise<string> => {
+export const createPrFromContribution = async (ghrepo: string, source: string, branch: string, changedDocument: string, title: string, desc: string): Promise<string> => {
   const authenticatedUserInfo = await getUserInfo(localStorage.getItem('token') as string);
   
   const owner = ghrepo.split('/')[0];
   const repo = ghrepo.split('/')[1];
   const newOwner = authenticatedUserInfo.login;
-  const newBranch = "new-branch-petal-app";
+  const newBranch = "new-branch-petal" + Math.floor(Math.random() * 1000);
   const commitMessage = title;
   const path = source;
   const content = changedDocument;
@@ -141,6 +141,7 @@ export const createPrFromContribution = async (ghrepo: string, source: string, c
       owner,
       repo,
       newOwner,
+      branch,
       newBranch,
       commitMessage,
       change,

--- a/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
@@ -29,9 +29,9 @@ import { document as jditaToProsemirrorJson } from "../document";
  * This function currently fetches the document from the 'main' branch of the repository.
  * should use the GitHub API to dynamically determine the default branch of the repository.
  */
-export const fetchRawDocumentFromGitHub = async (ghrepo: string, source: string): Promise<string> => {
+export const fetchRawDocumentFromGitHub = async (ghrepo: string, source: string, branch: string): Promise<string> => {
   //TODO(YB): the branch should be passed as a parameter
-  const url = `https://raw.githubusercontent.com/${ghrepo}/main/${source}`;
+  const url = `https://raw.githubusercontent.com/${ghrepo}/${branch}/${source}`;
   const response = await fetch(url);
 
   //TODO: Handle errors
@@ -62,8 +62,8 @@ export const transformGitHubDocumentToProsemirrorJson = async (rawDocument: stri
  * @param source - The source path of the document within the repository.
  * @returns A promise that resolves to the transformed ProseMirror JSON document.
  */
-export const fetchAndTransform = async (ghrepo: string, source: string) => {
-  const rawDoc = await fetchRawDocumentFromGitHub(ghrepo, source);
+export const fetchAndTransform = async (ghrepo: string, source: string, branch: string) => {
+  const rawDoc = await fetchRawDocumentFromGitHub(ghrepo, source, branch);
   const jsonDoc = await transformGitHubDocumentToProsemirrorJson(rawDoc);
   return jsonDoc;
 };
@@ -119,7 +119,7 @@ export const createPrFromContribution = async (ghrepo: string, source: string, b
   const owner = ghrepo.split('/')[0];
   const repo = ghrepo.split('/')[1];
   const newOwner = authenticatedUserInfo.login;
-  const newBranch = "new-branch-petal" + Math.floor(Math.random() * 1000);
+  const newBranch = "new-branch-petal";
   const commitMessage = title;
   const path = source;
   const content = changedDocument;

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -32,7 +32,7 @@ export interface URLParams {
  * source = GitHub resource,
  * referer = Referer of the request
  */
-export const validKeys = ['ghrepo', 'source', 'referer'];
+export const validKeys = ['ghrepo', 'source', 'branch', 'referer'];
 
 /**
  * Retrieves the values of the valid URL parameters `ghrepo`, `source`, and `referer`

--- a/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
+++ b/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
@@ -28,6 +28,7 @@ describe('fetchRawDocumentFromGitHub', () => {
   it('should fetch the raw content of a document from a GitHub repository', async () => {
     const ghrepo = 'evolvedbinary/prosemirror-lwdita';
     const source = 'packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml';
+    const branch = 'main';
     const mockResponse = '<xml>Mock Content</xml>';
     // this will mock the next fetch request
     fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/main/${source}`, {
@@ -35,18 +36,19 @@ describe('fetchRawDocumentFromGitHub', () => {
       headers: { 'Content-Type': 'text/plain' },
     });
 
-    const result = await fetchRawDocumentFromGitHub(ghrepo, source);
+    const result = await fetchRawDocumentFromGitHub(ghrepo, source, branch);
     expect(result).to.equal(mockResponse);
   });
 
   it('should handle errors when fetching the document', async () => {
     const ghrepo = 'evolvedbinary/prosemirror-lwdita';
     const source = 'packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml';
+    const branch = 'main';
     // this will mock the next fetch request
     fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/main/${source}`, 404);
 
     try {
-      await fetchRawDocumentFromGitHub(ghrepo, source);
+      await fetchRawDocumentFromGitHub(ghrepo, source, branch);
       throw new Error('Expected fetchRawDocumentFromGitHub to throw an error');
     } catch (error) {
       expect(error).to.be.instanceOf(Error);
@@ -162,7 +164,7 @@ describe('createPrFromContribution', () => {
       expect(body.owner).to.equal('evolvedbinary');
       expect(body.repo).to.equal('prosemirror-lwdita');
       expect(body.newOwner).to.equal('marmoure');
-      expect(body.newBranch).to.equal('new-branch-petal-app');
+      expect(body.newBranch).to.equal('new-branch-petal');
       expect(body.commitMessage).to.equal('Update the document');
       expect(body.change.path).to.equal(source);
       expect(body.change.content).to.equal(changedDocument);

--- a/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
+++ b/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
@@ -124,6 +124,7 @@ describe('createPrFromContribution', () => {
   it('should create a pull request from a contribution', async () => {
     const ghrepo = 'evolvedbinary/prosemirror-lwdita';
     const source = 'packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml';
+    const branch = 'main';
     const title = 'Update the document';
     const description = 'Update the document';
     const changedDocument = '<xml>Changed Content</xml>';
@@ -142,7 +143,7 @@ describe('createPrFromContribution', () => {
         login: 'marmoure',
       },
     }); 
-    await createPrFromContribution(ghrepo, source, changedDocument, title, description);
+    await createPrFromContribution(ghrepo, source, branch, changedDocument, title, description);
     const lastCall = fetchMock.lastCall('http://localhost:3000/api/github/integration') as fetchMock.MockCall;
     if (!lastCall) {
       throw new Error('No fetch call found for /api/github/integration');

--- a/packages/prosemirror-lwdita/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/tests/request.spec.ts
@@ -75,6 +75,11 @@ describe('When function getParameterValues() is passed a URL with', () => {
     invalidUrl = url + '?error=xyz';
     expect(getAndValidateParameterValues(invalidUrl)).to.deep.equal([{ key: 'error', value: 'xyz' }]);
   });
+
+  it('State parameter with the oauth code, it returns an object containing key-value pairs', () => {
+    validUrl = url + '?code=xyz&state=xyz';
+    expect(getAndValidateParameterValues(validUrl)).to.deep.equal([{ key: 'code', value: 'xyz' }, { key: 'state', value: 'xyz' }]);
+  });
 })
 
 // Function isValidParam()

--- a/packages/prosemirror-lwdita/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/tests/request.spec.ts
@@ -27,10 +27,11 @@ const url: string = 'https://example.com/';
 // Function getParameterValues()
 describe('When function getParameterValues() is passed a URL with', () => {
   it('valid parameters, it returns an object containing key-value pairs', () => {
-    validUrl = url + '?ghrepo=repo1&source=source1&referer=referer1';
+    validUrl = url + '?ghrepo=repo1&source=source1&branch=main&referer=referer1';
     expect(getAndValidateParameterValues(validUrl)).to.deep.equal([
       { key: 'ghrepo', value: 'repo1' },
       { key: 'source', value: 'source1' },
+      { key: 'branch', value: 'main' },
       { key: 'referer', value: 'referer1' },
     ]);
   });
@@ -81,6 +82,7 @@ describe('When function isValidParam() is passed a key', () => {
   it('that is a valid key, it returns true', () => {
     expect(isValidParam('ghrepo')).to.equal(true);
     expect(isValidParam('source')).to.equal(true);
+    expect(isValidParam('branch')).to.equal(true);
     expect(isValidParam('referer')).to.equal(true);
   });
   it('that is a invalid key, it returns true', () => {


### PR DESCRIPTION
Stop using `localstorage` for saving the url params as the user  gets redirected to the OAuth process and back, the url params are saved in `state` param that GitHub returns after OAuth is completed.
Encode url params such as: `ghrepo`, `branch`, `source`, `referer` in a base 64 string, the encoded string is used as state param check the docs for `state` params: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity

# How to test this PR:
* checkout the branch
* install dependencies
* start the demo `yarn run start:demo`
* open petal `localhost:1234`
* clear local storage
* make a request to `http://localhost:1234/?ghrepo=evolvedbinary/prosemirror-lwdita&source=packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml&branch=ignore/link&referer=htwsrhtshrts`
* notice the the redirect to GtiHub OAuth now contains `state` param
* authorize Petal GitHub App
* notice the return url from GitHub conainting `state` param
* Petal should render the document provided in the url above.