### PR TITLE
GitHub API calls retry on error

### DIFF
--- a/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
+++ b/packages/prosemirror-lwdita-backend/src/api/controller/github.controller.ts
@@ -108,8 +108,16 @@ export const commitChangesAndCreatePR = async (req: Request, res: Response) => {
   // dynamically import the module to avoid EMS and CJS incompatibility
   const { pushChangesAndCreatePullRequest } = await import('../modules/octokit.module.mjs');
   const { Octokit } = await import('@octokit/rest');
-  const octokit = new Octokit({
+  const { retry } = await import("@octokit/plugin-retry");
+
+  const OctokitWithRetry = Octokit.plugin(retry);
+
+  const octokit = new OctokitWithRetry({
     auth: token,
+    request: {
+      retries: 3,
+      retryAfter: 1, // retry after 1 second
+    },
   });
 
   const response = await pushChangesAndCreatePullRequest(octokit, owner, repo, newOwner, branch, newBranch, commitMessage, change, title, body);


### PR DESCRIPTION
Introduce `@octokit/plugin-retry` to the backend, And enable it.
This is mainly to prevent 404 and 5xx error from GitHub API.

How to test
1. checkout the branch
2. make sure you have a  clean state: no auth, no fork in your GitHub
3. Go over the GitHub integration process
4. Usually we notice the 404 error related to the branch name not found
5. Notice the error in the terminal output
6. Notice the request was tried again
7. The GitHub integration process should continue even with the 404.