### PR TITLE
Extract application configuration and info/error/success messages into config file

### DIFF
--- a/packages/prosemirror-lwdita-backend/package.json
+++ b/packages/prosemirror-lwdita-backend/package.json
@@ -41,6 +41,7 @@
     "test": "./test"
   },
   "dependencies": {
+    "@evolvedbinary/prosemirror-lwdita": "workspace:^",
     "@octokit/auth-oauth-user": "^5.1.1",
     "@octokit/rest": "^21.0.2",
     "@octokit/types": "^13.5.0",

--- a/packages/prosemirror-lwdita-backend/package.json
+++ b/packages/prosemirror-lwdita-backend/package.json
@@ -44,6 +44,7 @@
     "@octokit/auth-oauth-user": "^5.1.1",
     "@octokit/rest": "^21.0.2",
     "@octokit/types": "^13.5.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "octokit": "^4.0.2"
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.11",
     "@types/chai-as-promised": "^7.1.3",
+    "@types/cors": "^2",
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.21",
     "@types/mocha": "^10.0.7",

--- a/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
+++ b/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
@@ -20,7 +20,8 @@ import { createOAuthAppAuth } from "@octokit/auth-oauth-app";
 import { Endpoints } from "@octokit/types";
 import dotenv from 'dotenv'; 
 import { retry } from "@octokit/plugin-retry";
-dotenv.config();  // Load environment variables from .env file 
+import { PETAL_COMMITTER_EMAIL, PETAL_COMMITTER_NAME } from "@evolvedbinary/prosemirror-lwdita";
+dotenv.config();  // Load environment variables from .env file
 
 // user data type
 export type UserData = Endpoints["GET /user"]["response"]["data"];
@@ -224,8 +225,8 @@ const commitChanges = async (octokit: Octokit, owner: string, repo: string, bran
       tree: treeData.sha,
       parents: [lastCommit.sha],
       committer: {
-        name: "Petal GitHub App",
-        email: "petal@evolvedbianry.com"
+        name: PETAL_COMMITTER_NAME,
+        email: PETAL_COMMITTER_EMAIL
       }
     });
 

--- a/packages/prosemirror-lwdita-backend/src/server.ts
+++ b/packages/prosemirror-lwdita-backend/src/server.ts
@@ -17,8 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import express from 'express';
 import githubRouter from './api/routes/github.router';
-import { serverConfig, enableCors } from '@evolvedbinary/prosemirror-lwdita';
 import cors from 'cors';
+import { enableCors, serverConfig } from '@evolvedbinary/prosemirror-lwdita/dist/app-config';
 
 const app = express();
 app.use(express.json());
@@ -36,5 +36,5 @@ app.get('/', (req, res) => {
 });
 
 app.listen(3000, () => {
-  console.log('Server is running on' + serverConfig.apiUrl);
+  console.log('Server is running on ' + serverConfig.apiUrl);
 });

--- a/packages/prosemirror-lwdita-backend/src/server.ts
+++ b/packages/prosemirror-lwdita-backend/src/server.ts
@@ -36,5 +36,5 @@ app.get('/', (req, res) => {
 });
 
 app.listen(3000, () => {
-  console.log('Server is running on http://localhost:3000');
+  console.log('Server is running on' + serverConfig.apiUrl);
 });

--- a/packages/prosemirror-lwdita-backend/src/server.ts
+++ b/packages/prosemirror-lwdita-backend/src/server.ts
@@ -17,9 +17,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import express from 'express';
 import githubRouter from './api/routes/github.router';
+import { serverConfig, enableCors } from '@evolvedbinary/prosemirror-lwdita';
+import cors from 'cors';
 
 const app = express();
 app.use(express.json());
+
+if (enableCors) {
+  app.use(cors());
+}
 
 // add the github module to the http server
 // this will forward all requests starting with /api/github to the githubRouter

--- a/packages/prosemirror-lwdita-backend/tsconfig.json
+++ b/packages/prosemirror-lwdita-backend/tsconfig.json
@@ -5,7 +5,10 @@
     "rootDir": "src",
     "outDir": "dist",
     "module": "Node16",
-    "moduleResolution": "Node16"
+    "moduleResolution": "Node16",
+    "paths": {
+      "@evolvedbinary/prosemirror-lwdita/*": ["../prosemirror-lwdita/dist/*"]
+    }
   },
   "exclude": [
     "tests/*"

--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "prosemirror-commands";
 import { MenuElement, MenuItem, MenuItemSpec } from "prosemirror-menu";
-import { InputContainer, renderPrDialog } from "@evolvedbinary/prosemirror-lwdita";
+import { InputContainer, messageKeys, renderPrDialog } from "@evolvedbinary/prosemirror-lwdita";
 import { unTravel, URLParams } from "@evolvedbinary/prosemirror-lwdita";
 import { JditaSerializer } from "@evolvedbinary/lwdita-xdita";
 import { InMemoryTextSimpleOutputStreamCollector } from "@evolvedbinary/lwdita-xdita/dist/stream";
@@ -38,7 +38,7 @@ function openFile(input: InputContainer): Command {
         const reader = new FileReader();
         reader.readAsBinaryString(file);
         reader.onerror = () => {
-          showToast('Sorry, there was an error with reading the file. Please check if the file you tried to upload contains valid xml and try again', 'error');
+          showToast(messageKeys.error.toastFileUploadInvalid, 'error');
           console.log('Error reading file');
         };
         reader.onload = () => {
@@ -50,7 +50,7 @@ function openFile(input: InputContainer): Command {
           }
         };
       } else {
-        showToast('Sorry, something went wrong with opening the file', 'error');
+        showToast(messageKeys.error.toastFileUpload, 'error');
       }
     }
     try {
@@ -59,7 +59,7 @@ function openFile(input: InputContainer): Command {
       }
       if (dispatch) {
         if (!input.el) {
-          showToast('Sorry, the editor has problems with opening the file', 'error');
+          showToast(messageKeys.error.toastFileUploadNoInput, 'error');
           console.log('no input found');
           return false;
         }
@@ -69,7 +69,7 @@ function openFile(input: InputContainer): Command {
       }
       return true;
     } catch (e) {
-      showToast('Sorry, something went wrong with opening the file', 'error');
+      showToast(messageKeys.error.toastFileUpload, 'error');
       console.error(e);
       return false;
     }
@@ -147,7 +147,7 @@ function publishGithubDocument(urlParams: URLParams): Command {
       // show the publishing dialog
       renderPrDialog(urlParams.ghrepo, urlParams.source, urlParams.branch, updatedXdita);
     } else {
-      showToast('Sorry, it seems there is nothing in the editor to save and publish. Please try again.', 'error');
+      showToast(messageKeys.error.toastGitHubPublishNoEditorState, 'error');
       console.log('Nothing to publish, no EditorState has been dispatched.');
     }
   }
@@ -200,14 +200,14 @@ function saveFile(input: InputContainer): Command {
       if (link) {
         link.setAttribute('href', url);
       } else {
-        showToast('Apologies, something went wrong in the editor to provide you the download.', 'error');
+        showToast(messageKeys.error.toastFileDownload, 'error');
         console.log('The URL could not be assigned to the element, the link is not available.')
       }
       // TODO: Implement a callback function to check if the download has been completed
       // After the load has completed revoke the data URL with `URL.revokeObjectURL(url);`
       // See https://w3c.github.io/FileAPI/#examplesOfCreationRevocation
     } else {
-      showToast('Apologies, something went wrong in the editor to provide you the download.', 'error');
+      showToast(messageKeys.error.toastFileDownload, 'error');
       console.log('Nothing to download, no EditorState has been dispatched.');
     }
   }

--- a/packages/prosemirror-lwdita-demo/src/error-handler.ts
+++ b/packages/prosemirror-lwdita-demo/src/error-handler.ts
@@ -34,7 +34,7 @@ export function handleError() {
   const errorLink = document.getElementById('errorLink') as HTMLAnchorElement | null;
 
   if (errorHeadline && errorBody1 && errorBody2 && errorBody3 && errorLink) {
-    if (errorType === 'refererMissing') {
+    if (errorType === 'missingReferer') {
       errorHeadline.innerText = messageKeys.error.headline1;
       errorBody1.innerText = messageKeys.error.body1;
       errorBody2.innerText = messageKeys.error.body2;

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -25,7 +25,7 @@ import {
   hasConfirmedNotification,
   schema,
   showWelcomeNote,
-  serverURL,
+  serverConfig,
   menu,
   shortcuts,
   showErrorPage,
@@ -97,6 +97,6 @@ loadJsonDoc.then(jsonDoc => {
   }
 }).catch(error => {
   // TODO(AvC): Implement the default error page for this case
-  showErrorPage('fileUploadError', serverURL.value, error);
+  showErrorPage('fileUploadError', serverConfig.frontendUrl, error);
   console.error(error);
 });

--- a/packages/prosemirror-lwdita/src/app-config.ts
+++ b/packages/prosemirror-lwdita/src/app-config.ts
@@ -83,5 +83,13 @@ export const messageKeys = {
     body8: "Failed to load your file.",
     body9: "You could check your file and try again, or you can click on the link below to go back to the start page.",
     link1: "TODO: Content for 'messageKeys.error.link1'",
+    toastImageUpload: "Sorry, there was an error with uploading the image. Please check the image and try again.",
+    toastImageInsert: 'Sorry, something went wrong with inserting and saving the image.',
+    toastFileUploadInvalid: 'Sorry, there was an error with reading the file. Please check if the file you tried to upload contains valid xml and try again',
+    toastFileUpload: 'Sorry, something went wrong with opening the file',
+    toastFileUploadNoInput: 'Sorry, the editor has problems with opening the file',
+    toastFileDownload: 'Apologies, something went wrong in the editor to provide you the download.',
+    toastGitHubPublishNoEditorState: 'Sorry, it seems there is nothing in the editor to save and publish. Please try again.'
+
   },
 }

--- a/packages/prosemirror-lwdita/src/app-config.ts
+++ b/packages/prosemirror-lwdita/src/app-config.ts
@@ -15,20 +15,27 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+/**
+ * The URL of the Petal frontend and API
+ */
+export const serverConfig = {
+  frontendUrl: process.env.PARCEL_FRONTEND_URL || 'http://localhost:1234/',
+  apiUrl: process.env.PARCEL_API_URL || 'http://localhost:3000/',
+}
+
 export const clientID: { id: string, value: string } = {
   id: 'client_id',
   value: 'Iv23li0Pvl3E4crXIBQ0',
 };
 
-export const serverURL: { id: string, value: string } = {
-  id: 'server_url',
-  value: 'http://localhost:1234/',
-};
 /**
  * Whether or not to enable CORS
  */
 export const enableCors = process.env.ENABLE_CORS === 'true';
 
+export const GITHUB_API_ENPOINT_USER = 'api/github/user';
+export const GITHUB_API_ENPOINT_INTEGRATION = 'api/github/integration';
+export const GITHUB_API_ENPOINT_TOKEN = 'api/github/token';
 
 /**
  * Store all message strings for the application

--- a/packages/prosemirror-lwdita/src/app-config.ts
+++ b/packages/prosemirror-lwdita/src/app-config.ts
@@ -25,7 +25,7 @@ export const serverConfig = {
 
 export const clientID: { id: string, value: string } = {
   id: 'client_id',
-  value: 'Iv23li0Pvl3E4crXIBQ0',
+  value: process.env.GITHUB_CLIENT_ID || 'Iv23li0Pvl3E4crXIBQ0',
 };
 
 /**

--- a/packages/prosemirror-lwdita/src/app-config.ts
+++ b/packages/prosemirror-lwdita/src/app-config.ts
@@ -33,6 +33,21 @@ export const clientID: { id: string, value: string } = {
  */
 export const enableCors = process.env.ENABLE_CORS === 'true';
 
+/**
+ * The branch name prefix that Petal will generate in the user's repository
+ */
+export const PETAL_BRANCH_PREFIX = 'doc/petal-';
+
+/**
+ * The commit message subline that Petal will generate in the user's commit message
+ */
+export const PETAL_COMMIT_MESSAGE_SUFFIX = ' \n ------------------\n This is an automated PR made by the prosemirror-lwdita demo Editor';
+
+
+export const PETAL_BOT_USER = 'marmoure';
+export const PETAL_COMMITTER_NAME = 'Petal GitHub App';
+export const PETAL_COMMITTER_EMAIL = 'petal@evolvedbinary.com';
+
 export const GITHUB_API_ENPOINT_USER = 'api/github/user';
 export const GITHUB_API_ENPOINT_INTEGRATION = 'api/github/integration';
 export const GITHUB_API_ENPOINT_TOKEN = 'api/github/token';

--- a/packages/prosemirror-lwdita/src/app-config.ts
+++ b/packages/prosemirror-lwdita/src/app-config.ts
@@ -24,6 +24,11 @@ export const serverURL: { id: string, value: string } = {
   id: 'server_url',
   value: 'http://localhost:1234/',
 };
+/**
+ * Whether or not to enable CORS
+ */
+export const enableCors = process.env.ENABLE_CORS === 'true';
+
 
 /**
  * Store all message strings for the application

--- a/packages/prosemirror-lwdita/src/commands.ts
+++ b/packages/prosemirror-lwdita/src/commands.ts
@@ -22,6 +22,7 @@ import { Fragment, MarkType, Node, NodeType, ResolvedPos } from 'prosemirror-mod
 import { Command, EditorState, TextSelection, Transaction } from 'prosemirror-state';
 import { createPrFromContribution } from './github-integration/github.plugin';
 import { showPublicationResultError, showPublicationResultSuccess, showToast } from './toast';
+import { messageKeys } from './app-config';
 
 /**
  * Create a new Node and fill it with the args as attributes.
@@ -411,7 +412,7 @@ export function imageInputOverlay(callback: (args: any) => void, node?: Node): v
     const reader = new FileReader();
     reader.readAsDataURL(file);
     reader.onerror = () => {
-      showToast('Sorry, there was an error with uploading the image. Please check the image and try again.', 'error');
+      showToast(messageKeys.error.toastImageUpload, 'error');
     };
     reader.onload = () => {
       const img = new Image();
@@ -446,7 +447,7 @@ export function imageInputOverlay(callback: (args: any) => void, node?: Node): v
         })
       }
       reader.onerror = () => {
-        showToast('Sorry, there was an error with uploading the image. Please check the image and try again.', 'error');
+        showToast(messageKeys.error.toastImageUpload, 'error');
       };
 
     } else if (urlInput.value.length && !embeddedInput.checked) {
@@ -515,7 +516,7 @@ export function insertImage(type: NodeType): Command {
       return true;
     } catch (e) {
       console.error(e);
-      showToast('Sorry, something went wrong with inserting and saving the image.', 'error');
+      showToast(messageKeys.error.toastImageInsert, 'error');
       return false;
     }
   }

--- a/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import { xditaToJdita } from "@evolvedbinary/lwdita-xdita";
 import { document as jditaToProsemirrorJson } from "../document";
 import { showErrorPage } from "./request";
+import { GITHUB_API_ENPOINT_INTEGRATION, GITHUB_API_ENPOINT_TOKEN, GITHUB_API_ENPOINT_USER, PETAL_BRANCH_PREFIX, PETAL_COMMIT_MESSAGE_SUFFIX, serverConfig } from "../app-config";
 
 /**
  * Fetches the raw content of a document from a GitHub repository.
@@ -82,7 +83,7 @@ export const fetchAndTransform = async (ghrepo: string, source: string, branch: 
  */
 export const exchangeOAuthCodeForAccessToken = async (code: string): Promise<string> => {
   // build the URL to exchange the code for an access token
-  const url = `http://localhost:3000/api/github/token?code=${code}`;
+  const url = serverConfig.apiUrl + GITHUB_API_ENPOINT_TOKEN + `?code=${code}`;
   // fetch the access token
   const response = await fetch(url);
 
@@ -104,7 +105,7 @@ export const exchangeOAuthCodeForAccessToken = async (code: string): Promise<str
  * @returns A promise that resolves to a record containing user information.
  */
 export const getUserInfo = async (token: string): Promise<Record<string, string>> => {
-  const url = `http://localhost:3000/api/github/user`;
+  const url = serverConfig.apiUrl + GITHUB_API_ENPOINT_USER;
   const response = await fetch(url, {
     headers: {
       'authorization': `Bearer ${token}`

--- a/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
@@ -140,7 +140,7 @@ export const createPrFromContribution = async (ghrepo: string, source: string, b
   const repo = ghrepo.split('/')[1];
   const newOwner = authenticatedUserInfo.login;
   const date = new Date();
-  const newBranch = `doc/petal-${date.getFullYear()}${date.getMonth()}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}`;
+  const newBranch = PETAL_BRANCH_PREFIX + `${date.getFullYear()}${date.getMonth()}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}`;
   const commitMessage = title;
   const path = source;
   const content = changedDocument;
@@ -148,11 +148,11 @@ export const createPrFromContribution = async (ghrepo: string, source: string, b
     path,
     content
   };
-  const body = `${desc} \n ------------------\n This is an automated PR made by the prosemirror-lwdita demo`;
+  const body = `${desc}` + PETAL_COMMIT_MESSAGE_SUFFIX;
   // get the token from the local storage
   const token = localStorage.getItem('token');
   // make a post request to  /api/github/integration
-  const response = await fetch('http://localhost:3000/api/github/integration', {
+  const response = await fetch(serverConfig.apiUrl + GITHUB_API_ENPOINT_INTEGRATION, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -43,7 +43,7 @@ export const validKeys = ['ghrepo', 'source', 'branch', 'referer'];
  * @param url - URL string
  * @returns An array with key-value objects of the URL parameter values or a status string for handling the notifications
  */
-export function getAndValidateParameterValues(url: string): 'invalidParams' | 'refererMissing' | 'noParams' | { key: string, value: string }[] {
+export function getAndValidateParameterValues(url: string): 'invalidParams' | 'missingReferer' | 'noParams' | { key: string, value: string }[] {
   const parameters: { key: string, value: string }[] = [];
 
   const urlParts = url.split('?');
@@ -69,7 +69,7 @@ export function getAndValidateParameterValues(url: string): 'invalidParams' | 'r
   // TODO (AvC): Define all expected and allowed parameters in endpoints
   // and handle everything else as a redirect to the error page with e.g. error-type `unknownError`.
   // Currently all parameters that are not explicitly handled
-  // are treated as a `refererMissing` error, because we are simply
+  // are treated as a `missingReferer` error, because we are simply
   // checking if the referer is missing as a catch-all case.
 
   // Check if referer parameter is missing
@@ -79,7 +79,7 @@ export function getAndValidateParameterValues(url: string): 'invalidParams' | 'r
 
   // Return the status string for the notifications
   if (hasMissingReferer) {
-    return 'refererMissing';
+    return 'missingReferer';
   }
 
   if (hasMissingValues || hasInvalidParams) {
@@ -108,12 +108,12 @@ export function isOAuthCodeParam(key: string): boolean {
  *
  * @param parameters - The URL parameters
  */
-export function showNotification(parameters: 'authenticated' | 'invalidParams' | 'noParams' | 'refererMissing' |{ key: string, value: string }[]): void {
+export function showNotification(parameters: 'authenticated' | 'invalidParams' | 'noParams' | 'missingReferer' |{ key: string, value: string }[]): void {
   if (typeof parameters === 'object') {
     showToast('Success! You will be redirected to GitHub OAuth', 'success');
   } else if (parameters === 'invalidParams') {
     showToast('Your request is invalid.', 'error');
-  } else if (parameters === 'refererMissing') {
+  } else if (parameters === 'missingReferer') {
     showToast('Missing referer parameter.', 'error');
   } else if(parameters === 'authenticated') {
     showToast('You are authenticated.', 'success');
@@ -174,8 +174,8 @@ export function processRequest(): undefined | URLParams {
           const referer = new URLSearchParams(window.location.search).get('referer');
           handleInvalidRequest(referer);
         }
-        if (parameters === 'refererMissing') {
-          showErrorPage('refererMissing');
+        if (parameters === 'missingReferer') {
+          showErrorPage('missingReferer');
         }
         // Requests with object parameters from e.g. Git
       } else if (typeof parameters === 'object') {

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -16,7 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { showToast } from '../toast';
-import { clientID, serverURL } from '../app-config';
+import { clientID, serverConfig } from '../app-config';
 import { exchangeOAuthCodeForAccessToken } from './github.plugin';
 
 /**
@@ -127,7 +127,7 @@ export function redirectToGitHubOAuth(parameters: URLParams): void {
   const { id, value } = clientID;
   // Store the parameters in state to pass them to the redirect URL
   const state = btoa(`${JSON.stringify({ ...parameters })}`);
-  const redirectURL = serverURL.value;
+  const redirectURL = serverConfig.frontendUrl;
   window.location.href = `https://github.com/login/oauth/authorize?${id}=${value}&state=${state}&redirect_uri=${redirectURL}`;
 }
 
@@ -141,7 +141,7 @@ export function redirectToGitHubOAuth(parameters: URLParams): void {
  * @param errorMsg - Error message
  */
 export function showErrorPage(errorType: string, referer?: string, errorMsg?: string): void {
-  const errorPageUrl = `${serverURL.value}error.html?error-type=${encodeURIComponent(errorType)}&referer=${encodeURIComponent(referer || '')}&error-msg=${encodeURIComponent(errorMsg || '')}`;
+  const errorPageUrl = `${serverConfig.frontendUrl}error.html?error-type=${encodeURIComponent(errorType)}&referer=${encodeURIComponent(referer || '')}&error-msg=${encodeURIComponent(errorMsg || '')}`;
   window.location.href = errorPageUrl;
 }
 

--- a/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
+++ b/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
@@ -143,7 +143,7 @@ describe('createPrFromContribution', () => {
     fetchMock.getOnce(serverConfig.apiUrl + GITHUB_API_ENPOINT_USER, {
       status: 200,
       body: {
-        login: 'marmoure',
+        login: PETAL_BOT_USER,
       },
     }); 
     await createPrFromContribution(ghrepo, source, branch, changedDocument, title, description);
@@ -164,14 +164,14 @@ describe('createPrFromContribution', () => {
       const body = JSON.parse(options.body as string);
       expect(body.owner).to.equal('evolvedbinary');
       expect(body.repo).to.equal('prosemirror-lwdita');
-      expect(body.newOwner).to.equal('marmoure');
+      expect(body.newOwner).to.equal(PETAL_BOT_USER);
       const date = new Date();
-      expect(body.newBranch).to.equal(`doc/petal-${date.getFullYear()}${date.getMonth()}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}`);
+      expect(body.newBranch).to.equal(PETAL_BRANCH_PREFIX + `${date.getFullYear()}${date.getMonth()}${date.getDate()}${date.getHours()}${date.getMinutes()}${date.getSeconds()}`);
       expect(body.commitMessage).to.equal('Update the document');
       expect(body.change.path).to.equal(source);
       expect(body.change.content).to.equal(changedDocument);
       expect(body.title).to.equal('Update the document');
-      expect(body.body).to.equal('Update the document \n ------------------\n This is an automated PR made by the prosemirror-lwdita demo');
+      expect(body.body).to.equal('Update the document' + PETAL_COMMIT_MESSAGE_SUFFIX);
     }
   });
 });

--- a/packages/prosemirror-lwdita/tests/request.spec.ts
+++ b/packages/prosemirror-lwdita/tests/request.spec.ts
@@ -48,17 +48,17 @@ describe('When function getParameterValues() is passed a URL with', () => {
 
   it('one valid parameter, but the rest is missing, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo=xyz';
-    expect(getAndValidateParameterValues(invalidUrl)).to.equal('refererMissing');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('missingReferer');
   });
 
   it('two missing parameters, it returns string "invalidParams"', () => {
     invalidUrl = url + '?ghrepo';
-    expect(getAndValidateParameterValues(invalidUrl)).to.equal('refererMissing');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('missingReferer');
   });
 
   it('any parameter that is not matching any of the expected keys, it returns string "invalidParams"', () => {
     invalidUrl = url + '?xyz';
-    expect(getAndValidateParameterValues(invalidUrl)).to.equal('refererMissing');
+    expect(getAndValidateParameterValues(invalidUrl)).to.equal('missingReferer');
   });
 
   it('no parameters at all, it returns string "noParams"', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,6 +364,7 @@ __metadata:
     "@octokit/types": "npm:^13.5.0"
     "@types/chai": "npm:^4.3.11"
     "@types/chai-as-promised": "npm:^7.1.3"
+    "@types/cors": "npm:^2"
     "@types/dotenv": "npm:^8.2.0"
     "@types/express": "npm:^4.17.21"
     "@types/mocha": "npm:^10.0.7"
@@ -374,6 +375,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^7.16.0"
     chai: "npm:^4.3.10"
     chai-as-promised: "npm:^7.1.2"
+    cors: "npm:^2.8.5"
     dotenv: "npm:^16.4.5"
     eslint: "npm:^8.57.0"
     eslint-plugin-notice: "npm:^1.0.0"
@@ -2221,6 +2223,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cors@npm:^2":
+  version: 2.8.17
+  resolution: "@types/cors@npm:2.8.17"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/457364c28c89f3d9ed34800e1de5c6eaaf344d1bb39af122f013322a50bc606eb2aa6f63de4e41a7a08ba7ef454473926c94a830636723da45bf786df032696d
+  languageName: node
+  linkType: hard
+
 "@types/dotenv@npm:^8.2.0":
   version: 8.2.0
   resolution: "@types/dotenv@npm:8.2.0"
@@ -3422,6 +3433,16 @@ __metadata:
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
   checksum: 10c0/980a37a93956d0de8a828ce508f9b9e3317039d68922ca79995421944146700e4aaf490a6dbfebcb1c5292a7184600c7710b957d724be1e37b8254c6bc0fe246
+  languageName: node
+  linkType: hard
+
+"cors@npm:^2.8.5":
+  version: 2.8.5
+  resolution: "cors@npm:2.8.5"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10c0/373702b7999409922da80de4a61938aabba6929aea5b6fd9096fefb9e8342f626c0ebd7507b0e8b0b311380744cc985f27edebc0a26e0ddb784b54e1085de761
   languageName: node
   linkType: hard
 
@@ -6600,6 +6621,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-assign@npm:^4":
+  version: 4.1.1
+  resolution: "object-assign@npm:4.1.1"
+  checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.13.1":
   version: 1.13.1
   resolution: "object-inspect@npm:1.13.1"
@@ -8532,7 +8560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vary@npm:~1.1.2":
+"vary@npm:^1, vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f

--- a/yarn.lock
+++ b/yarn.lock
@@ -359,6 +359,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@evolvedbinary/prosemirror-lwdita-backend@workspace:packages/prosemirror-lwdita-backend"
   dependencies:
+    "@evolvedbinary/prosemirror-lwdita": "workspace:^"
     "@octokit/auth-oauth-user": "npm:^5.1.1"
     "@octokit/rest": "npm:^21.0.2"
     "@octokit/types": "npm:^13.5.0"


### PR DESCRIPTION
This PR will facilitate configuring following features in `./packages/prosemirror-lwdita/app-config.ts`:
* Strings for error page and toasts containing error/success/info messages 
* serverURLs
* GitHub API endpoints (e.g. for easily creating URLs in test suite)
* enabling/disabling CORS
* Petal App User / Email 
* Default text modules for Petal Commit messages
---
Note: This PR is branched off `feature/enhance-error-page`, which is currently in review in PR https://github.com/evolvedbinary/prosemirror-lwdita/pull/416. Needs to rebased onto main after #416 it is merged.