### PR TITLE
Update the raw link api

### DIFF
--- a/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
@@ -34,7 +34,10 @@ import { showToast } from "../toast";
  * should use the GitHub API to dynamically determine the default branch of the repository.
  */
 export const fetchRawDocumentFromGitHub = async (ghrepo: string, source: string, branch: string): Promise<string> => {
-  const url = `https://raw.githubusercontent.com/${ghrepo}/${branch}/${source}`;
+  // GitHub changes the raw api URL from `main` to `refs/heads/main` 
+  // https://raw.githubusercontent.com/evolvedbinary/prosemirror-lwdita/main/packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml
+  // https://raw.githubusercontent.com/evolvedbinary/prosemirror-lwdita/refs/heads/main/packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml
+  const url = `https://raw.githubusercontent.com/${ghrepo}/refs/heads/${branch}/${source}`;
   const response = await fetch(url);
 
   if (!response.ok) {

--- a/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
+++ b/packages/prosemirror-lwdita/tests/github.plugin.spec.ts
@@ -32,7 +32,7 @@ describe('fetchRawDocumentFromGitHub', () => {
     const branch = 'main';
     const mockResponse = '<xml>Mock Content</xml>';
     // this will mock the next fetch request
-    fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/main/${source}`, {
+    fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/refs/heads/main/${source}`, {
       body: mockResponse,
       headers: { 'Content-Type': 'text/plain' },
     });
@@ -46,7 +46,7 @@ describe('fetchRawDocumentFromGitHub', () => {
     const source = 'packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml';
     const branch = 'main';
     // this will mock the next fetch request
-    fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/main/${source}`, 404);
+    fetchMock.getOnce(`https://raw.githubusercontent.com/${ghrepo}/refs/heads/main/${source}`, 404);
 
     try {
       await fetchRawDocumentFromGitHub(ghrepo, source, branch);


### PR DESCRIPTION
Seems like Github updated the raw link urls to include `ref/head` now.