### PR TITLE
Add DITA MIME type and allow `.dita` files to be uploaded to the editor

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -93,7 +93,7 @@ export function openFileMenuItem(): MenuElement {
       input.el = document.createElement('input');
       input.el.type = 'file';
       input.el.id = 'fileUpload';
-      input.el.accept = 'application/xml,.xml';
+      input.el.accept = 'application/dita+xml,application/xml,.xml,.dita';
       input.el.title = 'Upload an XDITA file';
       const label = document.createElement('label');
       label.setAttribute('for', 'fileUpload');


### PR DESCRIPTION
Before, only xml files where allowed to be uploaded via the "Upload" button in the editor.  
Now, also `dita` files can be uploaded. 