### PR TITLE
Copy the whole dist folder

### DIFF
--- a/packages/prosemirror-lwdita-backend/README.md
+++ b/packages/prosemirror-lwdita-backend/README.md
@@ -73,7 +73,7 @@ $ yarn dist
 Copy the server bundle files from the `dist/bundle` folder of the Petal Backend to the folder on your server where you will run the API applucation from. We are using `/opt/petal-backend`. You will need to make sure that folder exists on the server before running this command.
 
 ```shell
-$ scp -r dist/bundle/server.bundle.js* ubuntu@petal.evolvedbinary.com:/opt/petal-backend/
+$ scp -r dist/* ubuntu@petal.evolvedbinary.com:/opt/petal-backend/
 ```
 
 ### 3. Configure SystemD to manage the Backend as a service
@@ -95,7 +95,7 @@ After=syslog.target
 Type=simple
 User=petal-backend
 Group=petal-backend
-ExecStart=/usr/bin/node /opt/petal-backend/server.bundle.js
+ExecStart=/usr/bin/node /opt/petal-backend/bundle/server.bundle.js
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The whole `dist` dir is needed when trying to run the backend on production server.