### PR TITLE
Images should point to the base url

### DIFF
--- a/packages/prosemirror-lwdita-demo/package.json
+++ b/packages/prosemirror-lwdita-demo/package.json
@@ -52,10 +52,12 @@
     "prosemirror-menu": "^1.2.4",
     "prosemirror-model": "^1.23.0",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-view": "^1.34.3"
+    "prosemirror-view": "^1.34.3",
+    "urijs": "^1.19.11"
   },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.12.0",
+    "@types/urijs": "^1.19.25",
     "@typescript-eslint/eslint-plugin": "^8.11.0",
     "@typescript-eslint/parser": "^8.11.0",
     "cypress": "^13.15.1",

--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -153,12 +153,11 @@ function publishGithubDocument(config: Config, localization: Localization, urlPa
     if (dispatch) {
       dispatch(state.tr);
       const documentNode = transformToJditaDocumentNode(state);
-      // get the base url from the referer
-      const baseUrl = urlParams.referer.split('/').slice(0, -1).join('/');
+      // get the base url from the referer & escape it for regex
+      const baseUrl = urijs(urlParams.referer).origin().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       // should match href="${baseUrl}" and remove it
-      const document = documentNode.replace(new RegExp(`href="${baseUrl}`, 'g'), (match) => {
-        const url = match.replace('href="', '');
-        return `href="${urijs(url).relativeTo(baseUrl).href()}`;
+      const document = documentNode.replace(new RegExp(`href="(${baseUrl}[^"]*)"`, 'g'), (_match,url) => {
+        return `href="${urijs(url).relativeTo(urlParams.referer).href()}"`;
       });
       // show the publishing dialog
       renderPrDialog(config, localization, urlParams.ghrepo, urlParams.source, urlParams.branch, document);

--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -152,9 +152,13 @@ function publishGithubDocument(config: Config, localization: Localization, urlPa
     if (dispatch) {
       dispatch(state.tr);
       const documentNode = transformToJditaDocumentNode(state);
+      // remove the base url from the documentNode
+      const baseUrl = urlParams.referer.split('/').slice(0, -1).join('/');
+      // doing the opposite of rawDoc.replace(/href="([^"]+)"/g, `href="${baseUrl}/$1"`);
+      const document = documentNode.replace(new RegExp(baseUrl, 'g'), '');
 
       // show the publishing dialog
-      renderPrDialog(config, localization, urlParams.ghrepo, urlParams.source, urlParams.branch, documentNode);
+      renderPrDialog(config, localization, urlParams.ghrepo, urlParams.source, urlParams.branch, document);
     } else {
       showToast(localization.t("error.toastGitHubPublishNoEditorState"), 'error');
       console.log('Nothing to publish, no EditorState has been dispatched.');

--- a/packages/prosemirror-lwdita-demo/src/example.ts
+++ b/packages/prosemirror-lwdita-demo/src/example.ts
@@ -74,7 +74,7 @@ async function entryPoint() {
   let loadJsonDoc = jsonDocLoader;
   // if the URL parameters are present, fetch the document from GitHub
   if(urlParams) {
-    loadJsonDoc = fetchAndTransform(config, urlParams.ghrepo, urlParams.source, urlParams.branch);
+    loadJsonDoc = fetchAndTransform(config, urlParams.ghrepo, urlParams.source, urlParams.branch, urlParams.referer);
   }
 
   // render the prosemirror document

--- a/packages/prosemirror-lwdita/package.json
+++ b/packages/prosemirror-lwdita/package.json
@@ -65,13 +65,15 @@
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.10.1",
     "prosemirror-view": "^1.34.3",
-    "toastify-js": "^1.12.0"
+    "toastify-js": "^1.12.0",
+    "urijs": "^1.19.11"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.9",
     "@types/node": "^22.7.9",
     "@types/toastify-js": "^1",
+    "@types/urijs": "^1.19.25",
     "@typescript-eslint/eslint-plugin": "^8.11.0",
     "@typescript-eslint/parser": "^8.11.0",
     "chai": "^4.3.10",

--- a/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/github.plugin.ts
@@ -75,9 +75,12 @@ export const transformGitHubDocumentToProsemirrorJson = async (rawDocument: stri
  * @param branch - The branch from which to fetch the document.
  * @returns A promise that resolves to the transformed ProseMirror JSON document.
  */
-export const fetchAndTransform = async (config: Config, ghrepo: string, source: string, branch: string) => {
+export const fetchAndTransform = async (config: Config, ghrepo: string, source: string, branch: string, referer: string) => {
   const rawDoc = await fetchRawDocumentFromGitHub(config, ghrepo, source, branch);
-  const jsonDoc = await transformGitHubDocumentToProsemirrorJson(rawDoc);
+  // apply changes to the raw xml document and update all links to point to the base URL of the referer
+  const baseUrl = referer.split('/').slice(0, -1).join('/');
+  const updatedDoc = rawDoc.replace(/href="([^"]+)"/g, `href="${baseUrl}/$1"`);
+  const jsonDoc = await transformGitHubDocumentToProsemirrorJson(updatedDoc);
   return jsonDoc;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,7 @@ __metadata:
     "@evolvedbinary/prosemirror-lwdita": "workspace:^"
     "@evolvedbinary/prosemirror-lwdita-localization": "workspace:^"
     "@parcel/transformer-sass": "npm:^2.12.0"
+    "@types/urijs": "npm:^1.19.25"
     "@typescript-eslint/eslint-plugin": "npm:^8.11.0"
     "@typescript-eslint/parser": "npm:^8.11.0"
     cypress: "npm:^13.15.1"
@@ -372,6 +373,7 @@ __metadata:
     rimraf: "npm:^6.0.1"
     sass: "npm:^1.80.4"
     start-server-and-test: "npm:^2.0.8"
+    urijs: "npm:^1.19.11"
   languageName: unknown
   linkType: soft
 
@@ -424,6 +426,7 @@ __metadata:
     "@types/mocha": "npm:^10.0.9"
     "@types/node": "npm:^22.7.9"
     "@types/toastify-js": "npm:^1"
+    "@types/urijs": "npm:^1.19.25"
     "@typescript-eslint/eslint-plugin": "npm:^8.11.0"
     "@typescript-eslint/parser": "npm:^8.11.0"
     chai: "npm:^4.3.10"
@@ -451,6 +454,7 @@ __metadata:
     typedoc: "npm:^0.26.10"
     typedoc-plugin-missing-exports: "npm:^3.0.0"
     typescript: "npm:5.6.3"
+    urijs: "npm:^1.19.11"
   languageName: unknown
   linkType: soft
 
@@ -2501,6 +2505,13 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
+  languageName: node
+  linkType: hard
+
+"@types/urijs@npm:^1.19.25":
+  version: 1.19.25
+  resolution: "@types/urijs@npm:1.19.25"
+  checksum: 10c0/462464294f0cd5f2271e1ab760a45abe252a946559444188a4ad0edba39b1a8bff41b140b79596a5e3c44a5d0d29f78c9ab97b5e82efb1e8617093a549c22bf6
   languageName: node
   linkType: hard
 
@@ -9299,6 +9310,13 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"urijs@npm:^1.19.11":
+  version: 1.19.11
+  resolution: "urijs@npm:1.19.11"
+  checksum: 10c0/96e15eea5b41a99361d506e4d8fcc64dc43f334bd5fd34e08261467b6954b97a6b45929a8d6c79e2dc76aadfd6ca950e0f4bd7f3c0757a08978429634d07eda1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When using Petal Images should point to the base url of the referer.

How to test:
Visit http://dev.petal.evolvedbinary.com/?ghrepo=evolvedbinary/cityehr-documentation&source=cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita&branch=develop&referer=https://evolvedbinary.github.io/cityehr-documentation/verify-install.html
and check image source.