### PR TITLE
Render filename labels dynamically for "Publish" and "Download" buttons in the editor toolbar.

### DIFF
--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -36,8 +36,9 @@ function openFile(localization: Localization, input: InputContainer): Command {
     function fileSelected(this: HTMLInputElement, _event: Event) {
       if (input.el?.files?.length === 1) {
         const file = input.el.files[0];
-        const fileName = file.name.split('.xml');
+        const fileName = file.name;
         console.log(fileName[0]);
+        console.log('file.name', file.name);
         const reader = new FileReader();
         reader.readAsBinaryString(file);
         reader.onerror = () => {
@@ -47,7 +48,7 @@ function openFile(localization: Localization, input: InputContainer): Command {
         reader.onload = () => {
           if (dispatch && typeof reader.result === 'string') {
             localStorage.setItem('file', reader.result);
-            localStorage.setItem('fileName', fileName[0]);
+            localStorage.setItem('fileName', fileName);
             dispatch(state.tr);
             location.reload();
           }
@@ -111,6 +112,27 @@ export function openFileMenuItem(localization: Localization): MenuElement {
   });
 }
 
+
+/**
+ * Get stored file name from local storage
+ * 
+ * @returns a string with the stored file name or the default value 'Petal.xml'
+ */
+function getStoredFileName(): string {
+  return localStorage.getItem('fileName') || 'Petal.xml';
+}
+
+/**
+ * Get the file name from URL parameters or local storage
+ * 
+ * @param urlParams - URL parameters
+ * @returns a string with the file name
+ */
+function getFileName(urlParams: URLParams | null): string {
+  const storedFileName = getStoredFileName();
+  return urlParams ? urlParams.source.split('/').slice(-1)[0] : storedFileName;
+}
+
 /**
  * Creates a menu item for publishing to Github.
  * This function generates a menu item that allows users to publish a file
@@ -121,16 +143,15 @@ export function openFileMenuItem(localization: Localization): MenuElement {
  * @returns The menu element for publishing the file.
  */
 export function publishFileMenuItem(config: Config, localization: Localization, urlParams: URLParams): MenuElement {
-  const storedFileName = urlParams? urlParams.source.split('/').slice(-1) : 'Petal.xml';
-
+  const fileNameLabel = getFileName(urlParams);
   return new MenuItem({
     enable: () => true,
     render(_editorView) {
       const el = document.createElement('div');
       el.classList.add('ProseMirror-menuitem-file', 'publish');
       const link = document.createElement('a');
-      link.download = storedFileName;
-      link.textContent = 'Publish "' + storedFileName;
+      link.download = fileNameLabel;
+      link.textContent = 'Publish "' + fileNameLabel;
       link.id = 'publishFile';
       el.appendChild(link);
       return el;
@@ -177,7 +198,7 @@ function publishGithubDocument(config: Config, localization: Localization, urlPa
  */
 export function saveFileMenuItem(urlParams: URLParams, localization: Localization, _props: Partial<MenuItemSpec & { url: string }> = {}): MenuElement {
   const link = new InputContainer();
-  const storedFileName = urlParams? urlParams.source.split('/').slice(-1) : 'Petal.xml';
+  const fileName = getFileName(urlParams);
 
   return new MenuItem({
     enable: () => true,
@@ -185,8 +206,8 @@ export function saveFileMenuItem(urlParams: URLParams, localization: Localizatio
       const el = document.createElement('div');
       el.classList.add('ProseMirror-menuitem-file');
       const link = document.createElement('a');
-      link.download = storedFileName;
-      link.textContent = 'Download "' + storedFileName;
+      link.download = fileName;
+      link.textContent = 'Download "' + fileName;
       link.id = 'saveFile';
       el.appendChild(link);
       return el;

--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -37,8 +37,6 @@ function openFile(localization: Localization, input: InputContainer): Command {
       if (input.el?.files?.length === 1) {
         const file = input.el.files[0];
         const fileName = file.name;
-        console.log(fileName[0]);
-        console.log('file.name', file.name);
         const reader = new FileReader();
         reader.readAsBinaryString(file);
         reader.onerror = () => {

--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -149,7 +149,7 @@ export function publishFileMenuItem(config: Config, localization: Localization, 
       el.classList.add('ProseMirror-menuitem-file', 'publish');
       const link = document.createElement('a');
       link.download = fileNameLabel;
-      link.textContent = 'Publish "' + fileNameLabel;
+      link.textContent = 'Publish ' + fileNameLabel;
       link.id = 'publishFile';
       el.appendChild(link);
       return el;
@@ -205,7 +205,7 @@ export function saveFileMenuItem(urlParams: URLParams, localization: Localizatio
       el.classList.add('ProseMirror-menuitem-file');
       const link = document.createElement('a');
       link.download = fileName;
-      link.textContent = 'Download "' + fileName;
+      link.textContent = 'Download ' + fileName;
       link.id = 'saveFile';
       el.appendChild(link);
       return el;


### PR DESCRIPTION
Updates PR - https://github.com/evolvedbinary/prosemirror-lwdita/pull/497 - Fixes retrieving the file name from URL parameters as a string instead of an array.
Fixes retrieving filenames from uploaded files used in the stand-alone editor instead of always displaying the default name.

* get the entire filename and its file ending and store it to the localStorage
* if URL parameters are available for param source, retrieve the string after the last `/` and return it as a string
* if no parameters for source are available, render the filename label that has been stored in localStorage
* if no filename has been stored and no URL parameter has been passed, just render the default fallback, which is the start page file `petal.xml`