### PR TITLE
[feature] update to lwdita 3.2.0

### DIFF
--- a/packages/prosemirror-lwdita-demo/package.json
+++ b/packages/prosemirror-lwdita-demo/package.json
@@ -45,7 +45,7 @@
     "staticPath": "../prosemirror-lwdita/config.json"
   },
   "dependencies": {
-    "@evolvedbinary/lwdita-xdita": "^3.1.0",
+    "@evolvedbinary/lwdita-xdita": "^3.2.0",
     "@evolvedbinary/prosemirror-lwdita": "workspace:^",
     "@evolvedbinary/prosemirror-lwdita-localization": "workspace:^",
     "prosemirror-history": "^1.4.1",

--- a/packages/prosemirror-lwdita/package.json
+++ b/packages/prosemirror-lwdita/package.json
@@ -50,8 +50,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@evolvedbinary/lwdita-ast": "^3.1.0",
-    "@evolvedbinary/lwdita-xdita": "^3.1.0",
+    "@evolvedbinary/lwdita-ast": "^3.2.0",
+    "@evolvedbinary/lwdita-xdita": "^3.2.0",
     "@evolvedbinary/prosemirror-lwdita-localization": "workspace:^",
     "@types/chai-as-promised": "^7.1.3",
     "chai-as-promised": "^7.1.2",

--- a/packages/prosemirror-lwdita/tests/test-utils.ts
+++ b/packages/prosemirror-lwdita/tests/test-utils.ts
@@ -189,9 +189,7 @@ export const complexXdita = `<?xml version="1.0" encoding="UTF-8"?>
         <strong>strong</strong>
         and <sub>subscript</sub> and <sup>superscipt</sup> and <tt>tele type</tt> and
         <u>underline</u>
-        <image href="images/image.png">
-            <alt>alt text</alt>
-        </image>
+        <image href="images/image.png"><alt>alt text</alt></image>
     </title>
     <shortdesc>Short description of the full topic.</shortdesc>
     <prolog>
@@ -229,19 +227,13 @@ export const complexXdita = `<?xml version="1.0" encoding="UTF-8"?>
         <pre>Preformatted content</pre>
         <audio autoplay="false" controls="true" loop="false" muted="false">
             <desc>Theme song for the LwDITA podcast</desc>
-            <fallback>
-                <p>The theme song is not available.</p>
-            </fallback>
+            <fallback><p>The theme song is not available.</p></fallback>
             <media-source value="theme-song.mp3"/>
             <media-track srclang="en" value="theme-song.vtt"/>
         </audio>
         <video height="300px" width="400px" autoplay="false" controls="true" loop="false" muted="false">
             <desc>Video about the Sensei Sushi promise.</desc>
-            <fallback>
-                <image href="video-not-available.png">
-                    <alt>This video cannot be displayed.</alt>
-                </image>
-            </fallback>
+            <fallback><image href="video-not-available.png"><alt>This video cannot be displayed.</alt></image></fallback>
             <video-poster href="sensei-video.jpg"/>
             <media-source href="sensei-video.mp4"/>
             <media-track srclang="en" href="sensei-video.vtt"/>
@@ -279,9 +271,7 @@ export const complexXdita = `<?xml version="1.0" encoding="UTF-8"?>
         <fig>
             <title>Figure title</title>
             <desc>Figure description</desc>
-            <image href="images/image.png">
-                <alt>alt text</alt>
-            </image>
+            <image href="images/image.png"><alt>alt text</alt></image>
         </fig>
         <note>
             <p>Note content</p>
@@ -310,9 +300,7 @@ export const videoXdita = `<?xml version="1.0" encoding="UTF-8"?>
       <fig>
         <video xml:lang="en" outputclass="videoElement" width="640" height="360"  tabindex="1" controls="true" autoplay="false" loop="false" muted="false">
           <desc>Xiaomi Yeelight YLDP06YL Smart Light Bulb White</desc>
-          <fallback>
-            <p>Sorry, the video is not available.</p>
-          </fallback>
+          <fallback><p>Sorry, the video is not available.</p></fallback>
           <video-poster href="https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/1954_Kool-Aid_Commercial._Debut_of_Pitcher_Man.webm/120px--1954_Kool-Aid_Commercial._Debut_of_Pitcher_Man.webm.jpg" />
           <media-source href="https://commons.wikimedia.org/wiki/File:1954_Kool-Aid_Commercial._Debut_of_Pitcher_Man.webm" />
         </video>
@@ -359,9 +347,7 @@ export const imageXdita = `<?xml version="1.0" encoding="UTF-8"?>
     <section>
       <title>An Image</title>
       <fig>
-        <image xml:lang="en" format="test" dir="ltr" outputclass="imageElement" height="300px" width="300px" href="https://placekitten.com/300/300">
-          <alt>A kitten</alt>
-        </image>
+        <image xml:lang="en" format="test" dir="ltr" outputclass="imageElement" height="300px" width="300px" href="https://placekitten.com/300/300"><alt>A kitten</alt></image>
       </fig>
     </section>
   </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,20 +291,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@evolvedbinary/lwdita-ast@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@evolvedbinary/lwdita-ast@npm:3.1.0"
-  checksum: 10c0/3649716c07485b31a95d1d327759c45a195218555b7badf0b19c3322672776380016f8dec055b703ba5fda9cc9085c8d183a88064e5d151222871da9285010ff
+"@evolvedbinary/lwdita-ast@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@evolvedbinary/lwdita-ast@npm:3.2.0"
+  checksum: 10c0/b6250d6fd4c08f8a05ff3c0bbbc6372aecd2f18b440ecdf219da82ca1c89c366edbce48c79ea06560b699f264e8b18db9700b405fdf19e267a298fdd4a9586ed
   languageName: node
   linkType: hard
 
-"@evolvedbinary/lwdita-xdita@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@evolvedbinary/lwdita-xdita@npm:3.1.0"
+"@evolvedbinary/lwdita-xdita@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@evolvedbinary/lwdita-xdita@npm:3.2.0"
   dependencies:
-    "@evolvedbinary/lwdita-ast": "npm:^3.1.0"
+    "@evolvedbinary/lwdita-ast": "npm:^3.2.0"
     "@rubensworks/saxes": "npm:6.0.1"
-  checksum: 10c0/9e61898364c0d20bf693c60f3995c471b76be7cba5455a1725afc6ee89c77f56f9d2b4051b4865daffa28738512da7b807f039e5c76c9acbd6f54baaad94d415
+  checksum: 10c0/0767a185040ed2fdc4c8549abfe255d7be53c11def7c86a1841b6a2259d7d8529b971420db3ee3933bcc1c159d3187f265f674a5b172e836483a6fc80febaab0
   languageName: node
   linkType: hard
 
@@ -352,7 +352,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@evolvedbinary/prosemirror-lwdita-demo@workspace:packages/prosemirror-lwdita-demo"
   dependencies:
-    "@evolvedbinary/lwdita-xdita": "npm:^3.1.0"
+    "@evolvedbinary/lwdita-xdita": "npm:^3.2.0"
     "@evolvedbinary/prosemirror-lwdita": "workspace:^"
     "@evolvedbinary/prosemirror-lwdita-localization": "workspace:^"
     "@parcel/transformer-sass": "npm:^2.12.0"
@@ -418,8 +418,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@evolvedbinary/prosemirror-lwdita@workspace:packages/prosemirror-lwdita"
   dependencies:
-    "@evolvedbinary/lwdita-ast": "npm:^3.1.0"
-    "@evolvedbinary/lwdita-xdita": "npm:^3.1.0"
+    "@evolvedbinary/lwdita-ast": "npm:^3.2.0"
+    "@evolvedbinary/lwdita-xdita": "npm:^3.2.0"
     "@evolvedbinary/prosemirror-lwdita-localization": "workspace:^"
     "@types/chai": "npm:^4.3.11"
     "@types/chai-as-promised": "npm:^7.1.3"


### PR DESCRIPTION
Update to use the latest lwdita library, The changes from the serializer work can be seen here https://github.com/marmoure/cityehr-documentation/pull/3/files

* no extra white-space
* correct doctype
* images are acting nice

There was changes to the tests xml for the `image` and `fallback` as both can not have whitespace in them now, this is due to the `alt` node being considered mixed content