### PR TITLE
Build the project before running cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ jobs:
       - install-yarn
       - install-dependencies
       - run:
+          name: build
+          command: yarn build
+      - run:
           name: build-demo
           command: yarn build:demo
   run-cypress:
@@ -101,6 +104,9 @@ jobs:
       - run: "corepack enable"
       - cypress/install:
           package-manager: "yarn-berry"
+      - run:
+          name: build
+          command: yarn build
       - cypress/run-tests:
           cypress-command: yarn run test:demo
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ We provide a [small demo](prosemirror-lwdita-demo/src/) to showcase features and
 git clone https://github.com/evolvedbinary/prosemirror-lwdita.git
 cd prosemirror-lwdita
 yarn install
+# build the project libraries
+yarn build
 
 # start the demo
 yarn start:demo

--- a/packages/prosemirror-lwdita-demo/README.md
+++ b/packages/prosemirror-lwdita-demo/README.md
@@ -8,6 +8,8 @@ git clone https://github.com/evolvedbinary/prosemirror-lwdita.git
 cd prosemirror-lwdita
 yarn install
 
+# build the project libraries
+yarn build
 # start the demo
 yarn start:demo
 ```
@@ -41,6 +43,9 @@ $ sudo ufw enable
 
 ### 1. Build the demo
 ```shell
+# build the project libraries
+$ yarn build
+# build the demo
 $ yarn build:demo
 ```
 


### PR DESCRIPTION
The PR fixes the CI and allows for cypress tests to run again.