### PR TITLE
Remove obsolete console.log and fix the error logs

### DIFF
--- a/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
+++ b/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
@@ -81,9 +81,7 @@ export const authenticateWithOAuth = async (clientId: string, clientSecret: stri
       // The account object is mistyped in the current version of the Octokit library
       const account = installation.account as { login: string };
 
-      if(account.login === user.data.login && installation.repository_selection === "all") {
-        console.log("Installation found: ", installation);
-        
+      if(account.login === user.data.login && installation.repository_selection === "all") {        
         installId = installation.id;
         break;
       }

--- a/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
+++ b/packages/prosemirror-lwdita-demo/src/demo-plugin.ts
@@ -41,7 +41,7 @@ function openFile(localization: Localization, input: InputContainer): Command {
         reader.readAsBinaryString(file);
         reader.onerror = () => {
           showToast(localization.t("error.toastFileUploadInvalid"), 'error');
-          console.log('Error reading file');
+          console.error('Error reading file');
         };
         reader.onload = () => {
           if (dispatch && typeof reader.result === 'string') {
@@ -62,7 +62,7 @@ function openFile(localization: Localization, input: InputContainer): Command {
       if (dispatch) {
         if (!input.el) {
           showToast(localization.t("error.toastFileUploadNoInput"), 'error');
-          console.log('no input found');
+          console.error('no input found');
           return false;
         }
         input.el.value = '';
@@ -182,7 +182,7 @@ function publishGithubDocument(config: Config, localization: Localization, urlPa
       renderPrDialog(config, localization, urlParams.ghrepo, urlParams.source, urlParams.branch, document);
     } else {
       showToast(localization.t("error.toastGitHubPublishNoEditorState"), 'error');
-      console.log('Nothing to publish, no EditorState has been dispatched.');
+      console.error('Nothing to publish, no EditorState has been dispatched.');
     }
   }
 }
@@ -236,14 +236,14 @@ function saveFile(localization: Localization, _input: InputContainer): Command {
         link.setAttribute('href', url);
       } else {
         showToast(localization.t("error.toastFileDownload"), 'error');
-        console.log('The URL could not be assigned to the element, the link is not available.')
+        console.error('The URL could not be assigned to the element, the link is not available.')
       }
       // TODO: Implement a callback function to check if the download has been completed
       // After the load has completed revoke the data URL with `URL.revokeObjectURL(url);`
       // See https://w3c.github.io/FileAPI/#examplesOfCreationRevocation
     } else {
       showToast(localization.t("error.toastFileDownload"), 'error');
-      console.log('Nothing to download, no EditorState has been dispatched.');
+      console.error('Nothing to download, no EditorState has been dispatched.');
     }
   }
 }

--- a/packages/prosemirror-lwdita/src/commands.ts
+++ b/packages/prosemirror-lwdita/src/commands.ts
@@ -249,8 +249,6 @@ export function renderPrDialog(config: Config, localization: Localization, ghrep
       // Create a PR from the contribution
       createPrFromContribution(config, localization, ghrepo, source, branch, updatedXdita, title, description)
         .then((prURL: string) => {
-          console.log('The document has been published to GitHub.');
-          console.log('pr url:', prURL);
           // Show a user notification with the successful result and a link to the PR
           showPublicationResultSuccess(localization, prURL)
         }).catch((error: Error) => {

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -213,7 +213,7 @@ export function processRequest(config: Config, localization: Localization): unde
             // this is currently not implemeted, thus a simple toast notification for now
             // showErrorPage('missingAuthentication', '', errorParam.value);
             showToast('Please authenticate with GitHub', 'error');
-            console.log('processRequest(): error', errorParam.value);
+            console.error('processRequest(): error', errorParam.value);
           }
 
           exchangeOAuthCodeForAccessToken(config, localization, returnParams.code).then(({token, installation}) => {

--- a/packages/prosemirror-lwdita/tests/topic.spec.ts
+++ b/packages/prosemirror-lwdita/tests/topic.spec.ts
@@ -49,7 +49,7 @@ describe('document()', () => {
     await expect(
       xditaToJdita(topic(attrs))
         .then(jdita => document(jdita))
-        .catch(e => console.log('error:', e))
+        .catch(e => console.error('error:', e))
     ).to.eventually.become(pmjson);
   });
 });


### PR DESCRIPTION
There were console.log instances in the code that are obsolete and some were not needed, while some other error logs were marked as simple logs.

This PR removes some of those logs and fixes others.