### PR TITLE
Always branch off from the upstream branch, not the fork

### DIFF
--- a/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
+++ b/packages/prosemirror-lwdita-backend/src/api/modules/octokit.module.mts
@@ -155,13 +155,8 @@ const createFork = async (octokit: Octokit, owner: string, repo: string): Promis
  * @param newBranch - The name of the new branch to be created.
  * @returns A Promise that resolves to a BranchInfo object representing the newly created branch, or undefined if an error occurs.
  */
-const createBranch = async (octokit: Octokit, owner: string, repo: string, branch: string, newBranch: string): Promise<BranchInfo | undefined> => {
+const createBranch = async (octokit: Octokit, owner: string, newOwner: string, repo: string, branch: string, newBranch: string): Promise<BranchInfo | undefined> => {
   try {
-    // get the repo data
-    const { data: repoData } = await octokit.repos.get({
-      owner, // this should be the authenticated user name
-      repo,
-    });
 
     // get the default branch ref
     const { data: branchData } = await octokit.repos.getBranch({
@@ -173,10 +168,9 @@ const createBranch = async (octokit: Octokit, owner: string, repo: string, branc
     // get the last commit sha
     const lastCommitSha = branchData.commit.sha;
 
-    //TODO(YB): Check if the branch already exists
-    // create the new branch
+    // create the new branch based on upstream
     const { data: refData } = await octokit.git.createRef({
-      owner,
+      owner: newOwner,
       repo,
       ref: `refs/heads/${newBranch}`,
       sha: lastCommitSha,
@@ -322,7 +316,7 @@ export const pushChangesAndCreatePullRequest = async (octokit: Octokit, owner: s
       throw new Error("Error during fork creation");
     }
     // create a new branch
-    const createdBranch = await createBranch(octokit, newOwner, repo, branch, newBranch);
+    const createdBranch = await createBranch(octokit, owner, newOwner, repo, branch, newBranch);
     if(!createdBranch) {
       throw new Error("Error during branch creation");
     }


### PR DESCRIPTION
# The issue
When you create a PR from fork to upstream, the commit changes will show from an older commit not the head of the upstream, ex
A PRs made from the fork to upstream but it shows more changes then it really happned:
https://github.com/marmoure/xdita-sample/pull/3/files

# The fix
The new breach created by petal-bot will be pointing towards the upstream target branch head ,and not the fork one, this will ensure that the branch is always up to date, with what we want to change.
Here are two PRs created by me from the same state one with the fix and one without
https://github.com/marmoure/xdita-sample/pull/7/files
https://github.com/marmoure/xdita-sample/pull/8/files
Notice how the PR number 8 shows unwanted changes.

# How to test this PR:
1. Checkout main
2. You have to edit the config files (DM me)
3. Open http://localhost:1234/?ghrepo=evolvedbinary/cityehr-documentation&source=cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita&branch=develop&referer=https://evolvedbinary.github.io/cityehr-documentation/verify-install.html
4. Create a PR from petal with a minor change
5. Merge that PR
6. Visit the link above again and make another minor change
7. Create another PR
8. Notice it has the same changes from the old PR an the new change
9. Checkout this branch
10. Visit the link above
11. Make a minor change
12. Create a PR 
13. Notice how the change are only the new minor change 