### PR TITLE
Stop publishing the demo package as it's not a lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "eslint packages/* --ext .ts",
     "lint:fix": "eslint packages/* --ext .ts --fix",
     "start:backend": "yarn workspace @evolvedbinary/prosemirror-lwdita-backend start",
-    "publish": "yarn workspace @evolvedbinary/prosemirror-lwdita-localization npm publish --access public && yarn workspace @evolvedbinary/prosemirror-lwdita npm publish --access public && yarn workspace @evolvedbinary/prosemirror-lwdita-demo npm publish --access public"
+    "publish": "yarn workspace @evolvedbinary/prosemirror-lwdita-localization npm publish --access public && yarn workspace @evolvedbinary/prosemirror-lwdita npm publish --access public"
   },
   "engines": {
     "node": ">=20.10.0 <21",

--- a/packages/prosemirror-lwdita-demo/package.json
+++ b/packages/prosemirror-lwdita-demo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@evolvedbinary/prosemirror-lwdita-demo",
   "version": "2.5.1",
+  "private": true,
   "description": "Demo for ProseMirror LwDITA integration",
   "main": "index.html",
   "engines": {


### PR DESCRIPTION
# What's the issue
The demo package is not a lib that you can import to your project and there's no point of publishing it.


# The fix
Set the demo package to private to make sure it's never going to be published, and also remove the demo from the publish script.
The demo package should be Deleted from `npm`, THIS NEEDS TO BE DONE BY @adamretter.

# How to test this
1. Bump the version to "2.5.2"
2. run `yarn publish`
3. Note that the demo package did not get published