### PR TITLE
Document should allow only one topic

### DIFF
--- a/packages/prosemirror-lwdita/src/schema.ts
+++ b/packages/prosemirror-lwdita/src/schema.ts
@@ -446,7 +446,7 @@ export function schema(): Schema {
   browse(MapNode);
 
   (spec.nodes as NodeSpec).topic.content = 'title shortdesc? prolog? body?';
-  (spec.nodes as NodeSpec).doc.content = 'topic+';
+  (spec.nodes as NodeSpec).doc.content = 'topic';
 
   return new Schema(spec);
 }


### PR DESCRIPTION
This hotfix will prevent Prosemirror from creating multiple topics in the same document.