### PR TITLE
Handles browser reload issues

### DIFF
--- a/packages/prosemirror-lwdita-demo/cypress/e2e/github-inegration.cy.ts
+++ b/packages/prosemirror-lwdita-demo/cypress/e2e/github-inegration.cy.ts
@@ -160,11 +160,45 @@ describe('request the token after OAuth', () => {
     cy.url().should('eq', `http://localhost:1234/?code=${mockCode}&state=eyJnaHJlcG8iOiJldm9sdmVkYmluYXJ5L3Byb3NlbWlycm9yLWx3ZGl0YSIsInNvdXJjZSI6InBhY2thZ2VzL3Byb3NlbWlycm9yLWx3ZGl0YS1kZW1vL2V4YW1wbGUteGRpdGEvMDItc2hvcnQtZmlsZS54bWwiLCJicmFuY2giOiJtYWluIiwicmVmZXJyZXIiOiJodHdzcmh0c2hydHMifQ==`);
 
     cy.wait('@requestToken');
-    
+
     // assert the user was redirected to the installation page
     // github.com/apps/petal-demo/installations/new
     cy.url().should('include', 'integration=petal-bot');
   });
+});
+
+describe('Browser behaviours', () => {
+  it('should restore the original url after OAuth', () => {
+    // mock the GitHub OAuth URL
+    const mockCode = 'mock-user-code';
+    // Intercept the GitHub OAuth URL
+    const githubOAuthUrl = /https:\/\/github\.com\/login\/oauth\/authorize\?.*/;
+
+    // Intercept the OAuth request and mock the authentication process
+    cy.intercept('GET', githubOAuthUrl, {
+      statusCode: 302,
+      headers: { location: `http://localhost:1234/?code=${mockCode}&state=eyJnaHJlcG8iOiJldm9sdmVkYmluYXJ5L3Byb3NlbWlycm9yLWx3ZGl0YSIsInNvdXJjZSI6InBhY2thZ2VzL3Byb3NlbWlycm9yLWx3ZGl0YS1kZW1vL2V4YW1wbGUteGRpdGEvMDItc2hvcnQtZmlsZS54bWwiLCJicmFuY2giOiJtYWluIiwicmVmZXJyZXIiOiJodHdzcmh0c2hydHMifQ==` }
+    }).as('githubOAuth');
+
+    // Intercept the token request
+    const tokenRequest = /http:\/\/localhost:3000\/api\/github\/token\?.*/;
+    cy.intercept('GET', tokenRequest, {
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: {
+        token: 'mock-token',
+        installation: true
+      }
+    }).as('requestToken');
+
+    cy.visit('http://localhost:1234/?ghrepo=evolvedbinary/prosemirror-lwdita&source=packages/prosemirror-lwdita-demo/example-xdita/02-short-file.xml&branch=main&referrer=https://petal.evolvedbinary.com/')
+    // make sure the token request is done
+    cy.wait('@requestToken').should('have.property', 'response');
+    cy.get('@requestToken').its('response.statusCode').should('eq', 200);
+    // check the url state
+    cy.wait(500)
+      .url().should('eq', `http://localhost:1234/?ghrepo=evolvedbinary%2Fprosemirror-lwdita&source=packages%2Fprosemirror-lwdita-demo%2Fexample-xdita%2F02-short-file.xml&branch=main&referrer=htwsrhtshrts`)
+  })
 });
 
 describe('render publish button', () => {

--- a/packages/prosemirror-lwdita/src/github-integration/request.ts
+++ b/packages/prosemirror-lwdita/src/github-integration/request.ts
@@ -181,7 +181,17 @@ export function processRequest(config: Config, localization: Localization): unde
             showErrorPage(config, 'authenticationError', returnParams.referrer);
           });
 
-          return JSON.parse(atob(returnParams.state));
+          const state = JSON.parse(atob(returnParams.state))
+
+          // Replace the one-time OAuth callback URL with the original edit URL so that
+          // a page refresh does not attempt to reuse the already-spent code.
+          const editUrl = `/?ghrepo=${encodeURIComponent(state.ghrepo)}`
+            + `&source=${encodeURIComponent(state.source)}`
+            + `&branch=${encodeURIComponent(state.branch)}`
+            + `&referrer=${encodeURIComponent(state.referrer)}`;
+          history.replaceState({}, '', editUrl);
+
+          return state;
         }
       }
 


### PR DESCRIPTION
This PR adjusts the behavior to deal with browser refresh issue and Fixes #577 
Here's the breakdown:
1. A user click on Edit Me button
2. Redirected to Petal with a link: [petal.com?ghrepo=xyz&branch=xx&referer=xxx](http://petal.com/?ghrepo=xyz&branch=xx&referer=xxx)
3. Petal does the GitHub authentication and the url becomes: [petal.com?code=xxx&state=xxx](http://petal.com/?code=xxx&state=xxx)

If you refresh at this state it will crash due to the url params.

I added a new step after (3) completes the URL becomes: [petal.com?ghrepo=xyz&branch=xx&referer=xxx](http://petal.com/?ghrepo=xyz&branch=xx&referer=xxx)  which is the exact same one as the original Edit Me link and it will create an endless loop, if a user refresh the browser he will return to the same state, rendering browser refresh problem absolute.